### PR TITLE
Fix installed package check for centos 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V1.5.2
+- Fixed yum package installed check on CentOS 8
+
 V1.5.1
  - Updated inmanta.resources import due to name clash.
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 1.5.1
+version: 1.5.2.dev1587651357
 compiler_version: 2017.3

--- a/plugins/resources.py
+++ b/plugins/resources.py
@@ -467,13 +467,20 @@ class YumPackage(ResourceHandler):
         lines = yum_output[0].split("\n")
 
         output = self._parse_fields(lines[1:])
+        repo_keyword = (
+            "Repo"
+            if "Repo" in output
+            else "Repository"
+            if "Repository" in output
+            else None
+        )
 
-        if "Repo" not in output:
+        if not repo_keyword:
             return {"state": "removed"}
 
         state = "removed"
 
-        if output["Repo"] == "installed" or output["Repo"] == "@System":
+        if output[repo_keyword] == "installed" or output[repo_keyword] == "@System":
             state = "installed"
 
         # check if there is an update

--- a/plugins/resources.py
+++ b/plugins/resources.py
@@ -467,6 +467,9 @@ class YumPackage(ResourceHandler):
         lines = yum_output[0].split("\n")
 
         output = self._parse_fields(lines[1:])
+        # to decide if the package is installed or not, the "Repo" field can be used
+        # from the yum info output (for e.g., CentOS 7)
+        # the dnf info output (for e.g., CentOS 8) doesn't have this field, "Repository" can be used instead
         repo_keyword = (
             "Repo"
             if "Repo" in output


### PR DESCRIPTION
# Description

On CentOS 8, the "Repository" entry can be used instead of "Repo"

closes #68 

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature) -> deferred to #86 
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design
