### PR TITLE
fixed dict value null conversion to None in Jinja template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V2.0.5
+- Fixed dict value null conversion to None in Jinja template (#97)
+
 V2.0.4
 - Add support to run the tests on centos8
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 2.0.4
+version: 2.0.5.dev1596196359
 compiler_version: 2020.1

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -101,7 +101,7 @@ class JinjaDynamicProxy(DynamicProxy):
                 )
         else:
             # A native python object such as a dict
-            return getattr(instance, attribute)
+            return JinjaDynamicProxy.return_value(getattr(instance, attribute))
 
 
 class SequenceProxy(JinjaDynamicProxy):
@@ -142,7 +142,7 @@ class CallProxy(JinjaDynamicProxy):
     def __call__(self, *args, **kwargs):
         instance = self._get_instance()
 
-        return instance(*args, **kwargs)
+        return JinjaDynamicProxy.return_value(instance(*args, **kwargs))
 
 
 class IteratorProxy(JinjaDynamicProxy):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -189,3 +189,26 @@ def test_files_current_dir(project, cleanup_test_module):
 
     out = project.get_stdout().splitlines()
     assert ["testfile1"] == out
+
+
+def test_97_template_dict_null(project):
+    """
+        Use a dict with null
+    """
+    project.add_mock_file(
+        "templates",
+        "test.j2",
+        """
+{{ value.get("test") }}
+        """,
+    )
+
+    project.compile(
+        """
+import unittest
+value = {"test": null}
+std::print(std::template("unittest/test.j2"))
+        """
+    )
+
+    assert "None\n" in project.get_stdout()


### PR DESCRIPTION
# Description

fixed dict value null conversion to None in Jinja template

closes #97
# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
