### PR TITLE
Issue/147 dont start svc on reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V2.0.6
+- Ensure a do_reload() doesn't start a service (#147)
+
 V2.0.5
 - Pass PIP_INDEX_URL and PIP_PRE to the docker containers that run the tests.
 - Fixed dict value null conversion to None in Jinja template (#97)

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 2.0.5
+version: 2.0.6.dev1599141749
 compiler_version: 2020.1

--- a/plugins/resources.py
+++ b/plugins/resources.py
@@ -285,6 +285,8 @@ class SystemdService(ResourceHandler):
         """
             Reload this resource
         """
+        if resource.state == "stopped":
+            return
         ctx.info("Reloading service with reload-or-restart")
         self._io.run(
             self._systemd_path, ["reload-or-restart", "%s.service" % resource.name]


### PR DESCRIPTION
# Description

Ensure do_reload() doesn't start a service.

closes #147 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
