### PR TITLE
Piping and printing container exec stdout and stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,17 @@ Some of the tests run against systemd, which testing against on developers own s
 Instead this module has a docker file to run the tests in, so that they are nice and isolated:
 
 ```bash
-docker build . -t test-module-std
-docker run -d --rm --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --name std-tests test-module-std
+# Testing for cento7
+docker build . -f dockerfiles/centos7.Dockerfile -t test-module-std-centos7
+docker run -d --rm --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --name std-tests test-module-std-centos7
 docker exec std-tests env/bin/pytest tests -v
+docker stop std-tests
+
+# Testing for centos8
+docker build . -f dockerfiles/centos8.Dockerfile -t test-module-std-centos8
+docker run -d --rm --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --name std-tests test-module-std-centos8
+docker exec std-tests env/bin/pytest tests -v
+docker stop std-tests
 ```
 
 Stopping the container (`docker stop std-tests`) will also clean up the volumes.

--- a/tests/test_in_docker.py
+++ b/tests/test_in_docker.py
@@ -27,7 +27,7 @@ import pytest
 )
 def test_docker(docker_container):
     print(f"Running tests in container {docker_container}")
-    subprocess.run(
+    process = subprocess.Popen(
         [
             "sudo",
             "docker",
@@ -38,5 +38,13 @@ def test_docker(docker_container):
             "-v",
             "--junitxml=junit.xml",
         ],
-        check=True,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
     )
+    with process.stdout:
+        for line in iter(process.stdout):
+            print(line.decode('utf-8').strip())
+
+    exitcode = process.wait()
+
+    assert exitcode == 0, f"The process ended up with a bad return code: {exitcode}"

--- a/tests/test_in_docker.py
+++ b/tests/test_in_docker.py
@@ -27,7 +27,7 @@ import pytest
 )
 def test_docker(docker_container):
     print(f"Running tests in container {docker_container}")
-    process = subprocess.Popen(
+    process = subprocess.run(
         [
             "sudo",
             "docker",
@@ -38,13 +38,5 @@ def test_docker(docker_container):
             "-v",
             "--junitxml=junit.xml",
         ],
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
+        check=True,
     )
-    with process.stdout:
-        for line in iter(process.stdout):
-            print(line.decode("utf-8").strip())
-
-    exitcode = process.wait()
-
-    assert exitcode == 0, f"The process ended up with a bad return code: {exitcode}"

--- a/tests/test_in_docker.py
+++ b/tests/test_in_docker.py
@@ -43,7 +43,7 @@ def test_docker(docker_container):
     )
     with process.stdout:
         for line in iter(process.stdout):
-            print(line.decode('utf-8').strip())
+            print(line.decode("utf-8").strip())
 
     exitcode = process.wait()
 


### PR DESCRIPTION
# Description

1. Piping stdout and stderr of container process launching the container execution during testing, and printing them out.
  - [x] Ensure that if the docker exec fails, stdout and stderr are reported to the user.
  - [ ] Resolve the same issue in the docker_container fixture as well (see: conftest.py)
2. Updating README information about tests launching.

closes #198 

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
