### PR TITLE
Fix error reporting in test cases

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,17 +83,6 @@ def docker_container(request: SubRequest) -> Generator[str, None, None]:
     centos_version = request.param
     image_name = f"test-module-std-centos{centos_version}"
 
-    try:
-        subprocess.run(
-            ["sudo", "docker", "stop", image_name],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=True,
-        )
-    # Thrown if the container does not exists
-    except subprocess.CalledProcessError:
-        pass
-
     docker_build_cmd = ["sudo", "docker", "build", ".", "-t", image_name]
     pip_index_url = os.environ.get("PIP_INDEX_URL", None)
     if pip_index_url is not None:
@@ -124,7 +113,6 @@ def docker_container(request: SubRequest) -> Generator[str, None, None]:
                 image_name,
             ],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             check=True,
         )
         .stdout.decode("utf-8")


### PR DESCRIPTION
# Description

* Ensure `docker run` shows its stderr to the user.
* Remove the `docker stop` command, because it requires a container id or a container name instead of a image name as an argument.

closes #198 

# Self Check:

- [x] Attached issue to pull request
- [ ] ~~Changelog entry~~
- [ ] ~~Version number is bumped to dev version~~
- [x] Code is clear and sufficiently documented
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
