### PR TITLE
Fix inconsistent default value warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-V2.1.1
+V2.1.2
 - Fix inconsistent default value warning (#214)
 
 V2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 V2.1.1
+- Fix inconsistent default value warning (#214)
+
+V2.1.1
 - Use inmanta-dev-dependencies package
 
 V2.1.0

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 2.1.1
+version: 2.1.2.dev1605880183
 compiler_version: 2020.1

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -801,11 +801,9 @@ def is_set(obj: "any", attribute: "string") -> "bool":
 
 @plugin
 def server_ca() -> "string":
-    filename = Config.get("compiler_rest_transport", "ssl_ca_cert_file", "")
-    if filename == "":
+    filename = Config.get("compiler_rest_transport", "ssl_ca_cert_file", None)
+    if not filename:
         return ""
-    if filename is None:
-        raise Exception("%s does not exist" % filename)
 
     if not os.path.isfile(filename):
         raise Exception("%s isn't a valid file" % filename)
@@ -825,8 +823,8 @@ def server_ssl() -> "bool":
 
 @plugin
 def server_token(context: Context, client_types: "string[]" = ["agent"]) -> "string":
-    token = Config.get("compiler_rest_transport", "token", "")
-    if token == "":
+    token = Config.get("compiler_rest_transport", "token", None)
+    if not token:
         return ""
 
     # Request a new token for this agent

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -32,9 +32,9 @@ def log_does_not_contain(caplog, loggerpart, level, msg):
 @pytest.mark.parametrize(
     "plugin_call,config_option",
     [
-        ("std::server_token()", 'compiler_rest_transport.token'),
-        ("std::server_ca()", "compiler_rest_transport.ssl-ca-cert-file")
-    ]
+        ("std::server_token()", "compiler_rest_transport.token"),
+        ("std::server_ca()", "compiler_rest_transport.ssl-ca-cert-file"),
+    ],
 )
 def test_no_warnings(project, caplog, plugin_call, config_option):
     with caplog.at_level(logging.DEBUG):
@@ -43,7 +43,11 @@ def test_no_warnings(project, caplog, plugin_call, config_option):
             std::print({plugin_call})
         """
         )
-    assert log_does_not_contain(caplog, "inmanta.config", logging.WARNING,
-                                f"Inconsistent default value for option {config_option}: defined as None, got")
+    assert log_does_not_contain(
+        caplog,
+        "inmanta.config",
+        logging.WARNING,
+        f"Inconsistent default value for option {config_option}: defined as None, got",
+    )
 
     assert project.get_stdout() == "\n"

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,49 @@
+"""
+    Copyright 2020 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+import logging
+
+import pytest
+
+
+def log_does_not_contain(caplog, loggerpart, level, msg):
+    for record in caplog.get_records("call"):
+        logger_name, log_level, message = record.name, record.levelno, record.message
+        if msg in message:
+            if loggerpart in logger_name and level == log_level:
+                return False
+    return True
+
+
+@pytest.mark.parametrize(
+    "plugin_call,config_option",
+    [
+        ("std::server_token()", 'compiler_rest_transport.token'),
+        ("std::server_ca()", "compiler_rest_transport.ssl-ca-cert-file")
+    ]
+)
+def test_no_warnings(project, caplog, plugin_call, config_option):
+    with caplog.at_level(logging.DEBUG):
+        project.compile(
+            f"""
+            std::print({plugin_call})
+        """
+        )
+    assert log_does_not_contain(caplog, "inmanta.config", logging.WARNING,
+                                f"Inconsistent default value for option {config_option}: defined as None, got")
+
+    assert project.get_stdout() == "\n"

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -23,9 +23,8 @@ import pytest
 def log_does_not_contain(caplog, loggerpart, level, msg):
     for record in caplog.get_records("call"):
         logger_name, log_level, message = record.name, record.levelno, record.message
-        if msg in message:
-            if loggerpart in logger_name and level == log_level:
-                return False
+        if msg in message and loggerpart in logger_name and level == log_level:
+            return False
     return True
 
 


### PR DESCRIPTION
# Description

These options defined in core have a default value of `None`

closes #214 

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
