### PR TITLE
Added DictProxy to allow accessing dict items from templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V2.1.2
+- Added DictProxy to allow accessing dict items from templates (#20)
+
 V2.1.1
 - Use inmanta-dev-dependencies package
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 2.1.1
+version: 2.1.2.dev1605879901
 compiler_version: 2020.1

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -79,6 +79,9 @@ class JinjaDynamicProxy(DynamicProxy):
         if isinstance(value, DynamicProxy):
             return value
 
+        if isinstance(value, dict):
+            return DictProxy(value)
+
         if hasattr(value, "__len__"):
             return SequenceProxy(value)
 
@@ -102,6 +105,23 @@ class JinjaDynamicProxy(DynamicProxy):
         else:
             # A native python object such as a dict
             return JinjaDynamicProxy.return_value(getattr(instance, attribute))
+
+
+class DictProxy(JinjaDynamicProxy):
+    def __init__(self, mydict):
+        DynamicProxy.__init__(self, mydict)
+
+    def __getitem__(self, key):
+        instance = self._get_instance()
+        if not isinstance(key, str):
+            raise RuntimeException(self, "Expected string key, but got %s, %s is a dict" % (key, self._get_instance()))
+
+        return DynamicProxy.return_value(instance[key])
+
+    def __iter__(self):
+        instance = self._get_instance()
+
+        return IteratorProxy(instance.__iter__())
 
 
 class SequenceProxy(JinjaDynamicProxy):

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -114,7 +114,11 @@ class DictProxy(JinjaDynamicProxy):
     def __getitem__(self, key):
         instance = self._get_instance()
         if not isinstance(key, str):
-            raise RuntimeException(self, "Expected string key, but got %s, %s is a dict" % (key, self._get_instance()))
+            raise RuntimeException(
+                self,
+                "Expected string key, but got %s, %s is a dict"
+                % (key, self._get_instance()),
+            )
 
         return DynamicProxy.return_value(instance[key])
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -17,6 +17,7 @@
 """
 import os
 import shutil
+from typing import Dict
 
 import pytest
 
@@ -248,8 +249,7 @@ std::print(std::template("unittest/test.j2"))
         """
     )
 
-    expected_out: str = (
-        """
+    expected_out: str = """
 key-value pairs 1:
 x: 42
 y: 43
@@ -266,6 +266,5 @@ key-value-pairs 3
 x: 42
 y: 43
 z: 44
-        """
-    )
+    """
     assert expected_out.strip() in project.get_stdout()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -211,3 +211,61 @@ std::print(std::template("unittest/test.j2"))
     )
 
     assert "None\n" in project.get_stdout()
+
+
+def test_20_template_dict_items(project):
+    """
+    Iterate over and get dict values from template.
+    """
+    project.add_mock_file(
+        "templates",
+        "test.j2",
+        """
+key-value pairs 1:
+{% for key in mydict -%}
+    {{ key }}: {{ mydict[key] }}
+{% endfor %}
+
+key-value pairs 2:
+{% for key in mydict -%}
+    {{ key }}: {{ mydict.get(key) }}
+{% endfor %}
+
+key-value-pairs 3
+{% for key, value in mydict.items() -%}
+    {{ key }}: {{ value }}
+{% endfor %}
+        """,
+    )
+
+    mydict: Dict[str, int] = {"x": 42, "y": 43, "z": 44}
+    project.compile(
+        f"""
+import unittest
+
+mydict = {mydict}
+std::print(std::template("unittest/test.j2"))
+        """
+    )
+
+    expected_out: str = (
+        """
+key-value pairs 1:
+x: 42
+y: 43
+z: 44
+
+
+key-value pairs 2:
+x: 42
+y: 43
+z: 44
+
+
+key-value-pairs 3
+x: 42
+y: 43
+z: 44
+        """
+    )
+    assert expected_out.strip() in project.get_stdout()


### PR DESCRIPTION
# Description

Added DictProxy to allow accessing dict items from templates

closes #20

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
