### PR TITLE
added __len__ to DictProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V2.1.4
+- Added `__len__` to `DictProxy` to allow `{{ mydict | length }}` in templates (#218)
+
 V2.1.3
 - Added DictProxy to allow accessing dict items from templates (#20)
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 2.1.3
+version: 2.1.4.dev1606228045
 compiler_version: 2020.1

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -122,6 +122,9 @@ class DictProxy(JinjaDynamicProxy):
 
         return DynamicProxy.return_value(instance[key])
 
+    def __len__(self):
+        return len(self._get_instance())
+
     def __iter__(self):
         instance = self._get_instance()
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -268,3 +268,19 @@ y: 43
 z: 44
     """
     assert expected_out.strip() in project.get_stdout()
+
+
+def test_218_template_dict_len(project):
+    project.add_mock_file("templates", "test.j2", "{{ mydict | length }}")
+
+    mydict: Dict[str, int] = {"x": 42, "y": 43, "z": 44}
+    project.compile(
+        f"""
+import unittest
+
+mydict = {mydict}
+std::print(std::template("unittest/test.j2"))
+        """
+    )
+
+    assert project.get_stdout().strip() == str(len(mydict))


### PR DESCRIPTION
# Description

Adds a `__len__` method to `DictProxy` to allow `{{ mydict | length }}` in templates.

caused by #216
closes #218 

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
