### PR TITLE
Ensure gcc and python3-devel test dependencies in docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 V3.0.3
-- Ensure gcc and python3-devel are installed in order to compile asyncpg dependency
+-  Improved testing: Ensure asyncpg is installed using a pre-compiled python package
 
 V3.0.2
 - Add support for Jinja2 version 3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V3.0.3
+- Ensure gcc and python3-devel are installed in order to compile asyncpg dependency
+
 V3.0.2
 - Add support for Jinja2 version 3.0
 

--- a/dockerfiles/centos7.Dockerfile
+++ b/dockerfiles/centos7.Dockerfile
@@ -20,7 +20,7 @@ ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
 
-RUN yum install -y python3
+RUN yum install -y python3 python3-devel gcc
 
 RUN mkdir -p /module/std
 WORKDIR /module/std

--- a/dockerfiles/centos7.Dockerfile
+++ b/dockerfiles/centos7.Dockerfile
@@ -20,7 +20,7 @@ ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
 
-RUN yum install -y python3 python3-devel gcc
+RUN yum install -y python3
 
 RUN mkdir -p /module/std
 WORKDIR /module/std
@@ -32,7 +32,7 @@ COPY requirements.freeze requirements.freeze
 COPY requirements.txt requirements.txt
 COPY requirements.dev.txt requirements.dev.txt
 
-RUN env/bin/pip install -r requirements.txt -r requirements.dev.txt -c requirements.freeze
+RUN env/bin/pip install --only-binary asyncpg -r requirements.txt -r requirements.dev.txt -c requirements.freeze
 
 COPY module.yml module.yml
 COPY model model

--- a/dockerfiles/centos8.Dockerfile
+++ b/dockerfiles/centos8.Dockerfile
@@ -15,7 +15,7 @@ rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 VOLUME [ "/sys/fs/cgroup" ]
 
-RUN yum install -y python3 python3-devel gcc glibc-locale-source
+RUN yum install -y python3 glibc-locale-source
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
@@ -32,7 +32,7 @@ COPY requirements.txt requirements.txt
 COPY requirements.freeze requirements.freeze
 COPY requirements.dev.txt requirements.dev.txt
 
-RUN env/bin/pip install -r requirements.txt -r requirements.dev.txt -c requirements.freeze
+RUN env/bin/pip install --only-binary asyncpg -r requirements.txt -r requirements.dev.txt -c requirements.freeze
 
 COPY module.yml module.yml
 COPY model model

--- a/dockerfiles/centos8.Dockerfile
+++ b/dockerfiles/centos8.Dockerfile
@@ -15,7 +15,7 @@ rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 VOLUME [ "/sys/fs/cgroup" ]
 
-RUN yum install -y python3 glibc-locale-source
+RUN yum install -y python3 python3-devel gcc glibc-locale-source
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 3.0.2
+version: 3.0.3.dev1628662358
 compiler_version: 2020.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,1 +1,2 @@
 inmanta-dev-dependencies[module]==1.50.0
+wheel==0.37.0


### PR DESCRIPTION
# Description

Ensure that `gcc` and `python3-devel` are installed in the docker containers that run the test. The `asyncpg` package requires this from version `0.24.0`.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
