### PR TITLE
Added support to run the tests gainst the V2 version of this module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V3.0.7
+- Added support to run the tests against the V2 version of this module.
+
 V3.0.6
 - replace centos8 by rocky8 in dockerfiles and tests
 

--- a/dockerfiles/centos7.Dockerfile
+++ b/dockerfiles/centos7.Dockerfile
@@ -34,7 +34,9 @@ RUN rm -rf env && python3 -m venv env && env/bin/pip install -U pip
 # installed as a V2 module when it contains a inmanta_plugins directory.
 RUN if [ -e "inmanta_plugins" ]; then \
     env/bin/pip install --only-binary asyncpg -r requirements.dev.txt -c requirements.freeze; \
-    env/bin/inmanta module install .; \
+    rm -rf ./dist ; \
+    env/bin/inmanta module build; \
+    env/bin/pip install -c requirements.freeze ./dist/*.whl; \
 else \
     env/bin/pip install --only-binary asyncpg -r requirements.txt -r requirements.dev.txt -c requirements.freeze; \
 fi

--- a/dockerfiles/rocky8.Dockerfile
+++ b/dockerfiles/rocky8.Dockerfile
@@ -34,7 +34,9 @@ RUN rm -rf env && python3 -m venv env && env/bin/pip install -U pip
 # installed as a V2 module when it contains a inmanta_plugins directory.
 RUN if [ -e "inmanta_plugins" ]; then \
     env/bin/pip install --only-binary asyncpg -r requirements.dev.txt -c requirements.freeze; \
-    env/bin/inmanta module install .; \
+    rm -rf ./dist; \
+    env/bin/inmanta module build; \
+    env/bin/pip install -c requirements.freeze ./dist/*.whl; \
 else \
     env/bin/pip install --only-binary asyncpg -r requirements.txt -r requirements.dev.txt -c requirements.freeze; \
 fi

--- a/dockerfiles/rocky8.Dockerfile
+++ b/dockerfiles/rocky8.Dockerfile
@@ -25,18 +25,18 @@ ENV LANGUAGE=en_US.UTF-8
 RUN mkdir -p /module/std
 WORKDIR /module/std
 
-RUN python3 -m venv env
-RUN env/bin/pip install -U pip
+# Copy the entire module into the container
+COPY . .
 
-COPY requirements.txt requirements.txt
-COPY requirements.freeze requirements.freeze
-COPY requirements.dev.txt requirements.dev.txt
-
-RUN env/bin/pip install --only-binary asyncpg -r requirements.txt -r requirements.dev.txt -c requirements.freeze
-
-COPY module.yml module.yml
-COPY model model
-COPY plugins plugins
-COPY tests tests
+RUN rm -rf env && python3 -m venv env && env/bin/pip install -U pip
+# The module set tests convert the module into a V2 module, install it in the test
+# environment and run the tests against it. This code ensures that the module is
+# installed as a V2 module when it contains a inmanta_plugins directory.
+RUN if [ -e "inmanta_plugins" ]; then \
+    env/bin/pip install --only-binary asyncpg -r requirements.dev.txt -c requirements.freeze; \
+    env/bin/inmanta module install .; \
+else \
+    env/bin/pip install --only-binary asyncpg -r requirements.txt -r requirements.dev.txt -c requirements.freeze; \
+fi
 
 CMD ["/usr/sbin/init"]

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 3.0.6
+version: 3.0.7.dev1644324398
 compiler_version: 2020.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,8 @@ def pip_lock_file() -> None:
                 "@",
                 "-e",
                 "inmanta-dev-dependencies",
+                "-e",
+                "inmanta-module-",
                 "requirements.freeze.tmp",
             ],
             stdout=ff,


### PR DESCRIPTION
# Description

The module set tests convert the module into a V2 module, install it in a venv and run the tests against that. This PR makes sure that the std module supports this while running in Docker.

Part of inmanta/irt#898

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
