### PR TITLE
constrained MarkupSafe to compatible range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 V2.1.11
+- Constrained MarkupSafe dependency to compatible range
+
+V2.1.11
 - Improved testing: Replace centos8 by rocky8 in dockerfiles and tests
 
 V2.1.10
@@ -11,7 +14,7 @@ V2.1.8
 - Improved testing: prevent too many packages from being installed in the testing container
 
 V2.1.7
-- Improved testing: handle pip freeze bug: https://github.com/pypa/pip/issues/8174 
+- Improved testing: handle pip freeze bug: https://github.com/pypa/pip/issues/8174
 
 V2.1.6
 - Un-pin transitive dependencies in requirements.txt for improved backward compatibility

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 2.1.11
+version: 2.1.12.dev1645182963
 compiler_version: 2020.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ email_validator~=1.1
 pydantic~=1.8
 
 dataclasses~=0.7;python_version<'3.7'
+
+# Dependency of Jinja2, later versions not compatible with Jinja2~=2.11
+MarkupSafe~=2.0.0


### PR DESCRIPTION
# Description

MarkupSafe 2.1.0 is not compatible with Jinja 2.x.

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
