### PR TITLE
have dependabot track 3.6 incompatible updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V3.0.9
+- Have dependabot track 3.6 incompatible versions.
+
 V3.0.8
 - Select the correct docker container for test runs with INMANTA\_TEST\_INFRA\_SETUP=true based on the version of the venv running the tests.
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 3.0.8
+version: 3.0.9.dev1647336373
 compiler_version: 2020.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,3 @@
-inmanta-dev-dependencies[async]==1.75.0; python_version <= '3.6'
+inmanta-dev-dependencies[async]==1.76.0; python_version <= '3.6'
 inmanta-dev-dependencies[async]==2.8.0; python_version > '3.6'
 wheel==0.37.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,2 +1,3 @@
-inmanta-dev-dependencies[module]==1.76.0
+inmanta-dev-dependencies[async]==1.75.0; python_version <= '3.6'
+inmanta-dev-dependencies[async]==2.8.0; python_version > '3.6'
 wheel==0.37.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,3 @@
-inmanta-dev-dependencies[async]==1.76.0; python_version <= '3.6'
-inmanta-dev-dependencies[async]==2.8.0; python_version > '3.6'
+inmanta-dev-dependencies[module]==1.76.0; python_version <= '3.6'
+inmanta-dev-dependencies[module]==2.8.0; python_version > '3.6'
 wheel==0.37.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def fix_classname(testsuite: ElementTree.Element, suite: str) -> None:
 
 @pytest.fixture
 def pip_lock_file() -> None:
-    """ get all versions of inmanta packages into a freeze file, to make the environment inside docker like the one outside """
+    """get all versions of inmanta packages into a freeze file, to make the environment inside docker like the one outside"""
     with open("requirements.freeze.all", "w") as ff:
         subprocess.check_call([sys.executable, "-m", "pip", "freeze"], stdout=ff)
     with open("requirements.freeze.tmp", "w") as ff:


### PR DESCRIPTION
# Description

Dependabot was currently running with Python 3.6 due to the constraint on the `dataclasses` dependency coupled with its [naive attempt](https://github.com/dependabot/dependabot-core/blob/add0e471c1920e2a726273aee7f84a37429b31c6/python/lib/dependabot/python/file_parser/python_requirement_parser.rb#L32) to use an appropriate Python version. This PR bumps `inmanta-dev-dependencies` and indirectly makes sure that dependabot will use a newer Python version for future checks.

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
