### PR TITLE
Fix passing Undefined to plugins in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V3.1.1
+- Fix passing Undefined to plugins in templates
+
 V3.1.0
 - Add ResourceSet entity
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 3.1.0
+version: 3.1.1.dev1653996896
 compiler_version: 2020.8

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -249,9 +249,7 @@ def _get_template_engine(ctx):
 
 
 def _raise_if_contains_undefined(args: Tuple[object, ...]) -> None:
-    undef_args = [
-        arg for arg in args if isinstance(arg, jinja2.StrictUndefined)
-    ]
+    undef_args = [arg for arg in args if isinstance(arg, jinja2.StrictUndefined)]
     if undef_args:
         # Accessing an undefined value will raise the appropriate UndefinedError
         str(undef_args[0])

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -237,6 +237,12 @@ def _get_template_engine(ctx):
 
         def curywrapper(func):
             def safewrapper(*args):
+                undef_args = [
+                    arg for arg in args if isinstance(arg, jinja2.StrictUndefined)
+                ]
+                if undef_args:
+                    # Accessing an undefined value will raise the appropriate UndefinedError
+                    str(undef_args[0])
                 return JinjaDynamicProxy.return_value(func(*args))
 
             return safewrapper

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -28,7 +28,7 @@ from collections import defaultdict
 from copy import copy
 from itertools import chain
 from operator import attrgetter
-from typing import Any
+from typing import Any, Tuple
 
 import jinja2
 import pydantic
@@ -237,12 +237,7 @@ def _get_template_engine(ctx):
 
         def curywrapper(func):
             def safewrapper(*args):
-                undef_args = [
-                    arg for arg in args if isinstance(arg, jinja2.StrictUndefined)
-                ]
-                if undef_args:
-                    # Accessing an undefined value will raise the appropriate UndefinedError
-                    str(undef_args[0])
+                _raise_if_contains_undefined(args)
                 return JinjaDynamicProxy.return_value(func(*args))
 
             return safewrapper
@@ -251,6 +246,15 @@ def _get_template_engine(ctx):
 
     engine_cache = env
     return env
+
+
+def _raise_if_contains_undefined(args: Tuple[object, ...]) -> None:
+    undef_args = [
+        arg for arg in args if isinstance(arg, jinja2.StrictUndefined)
+    ]
+    if undef_args:
+        # Accessing an undefined value will raise the appropriate UndefinedError
+        str(undef_args[0])
 
 
 def _extend_path(ctx: Context, path: str):


### PR DESCRIPTION
# Description

My understanding was that an Error should be raised before (or instead of) converting `Undefined` to a `DynamicProxy`. 

closes #213 

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
