### PR TITLE
[FIX] check that environment is None before casting to str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V3.1.1
+- Fix environment check for None value
+
 V3.1.0
 - Add ResourceSet entity
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 3.1.0
+version: 3.1.1.dev1654091735
 compiler_version: 2020.8

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -787,7 +787,7 @@ def environment() -> "string":
     """
     Return the environment id
     """
-    env = str(Config.get("config", "environment", None))
+    env = Config.get("config", "environment", None)
 
     if env is None:
         raise Exception(

--- a/tests/test_unknown.py
+++ b/tests/test_unknown.py
@@ -42,6 +42,9 @@ def test_is_unknown_should_be_true(project):
 
 
 def test_unknown_environment(project):
+    """
+    Ensure that an exception is raised when the std::environment() plugin is called when no environment is configured.
+    """
     with pytest.raises(Exception):
         project.compile(
             """

--- a/tests/test_unknown.py
+++ b/tests/test_unknown.py
@@ -16,6 +16,8 @@
     Contact: code@inmanta.com
 """
 
+import pytest
+
 
 def test_is_unknown_should_be_false(project):
     project.compile(
@@ -37,3 +39,12 @@ def test_is_unknown_should_be_true(project):
     )
 
     assert project.get_stdout() == "True\n"
+
+
+def test_unknown_environment(project):
+    with pytest.raises(Exception):
+        project.compile(
+            """
+        env_name = std::environment_name()
+        """
+        )

--- a/tests/test_unknown.py
+++ b/tests/test_unknown.py
@@ -31,8 +31,8 @@ def test_is_unknown_should_be_false(project):
 def test_is_unknown_should_be_true(project):
     project.compile(
         """
-    env_name = std::environment_name()
-    std::print(std::is_unknown(env_name))
+    unknown_env_int = std::get_env_int("UNKNOWN_ENV_INT")
+    std::print(std::is_unknown(unknown_env_int))
     """
     )
 

--- a/tests/test_unknown.py
+++ b/tests/test_unknown.py
@@ -45,6 +45,6 @@ def test_unknown_environment(project):
     with pytest.raises(Exception):
         project.compile(
             """
-        env_name = std::environment_name()
+        env_name = std::environment()
         """
         )


### PR DESCRIPTION
# Description

Check that environment is None before casting to str

closes #282 

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
