### PR TITLE
don't allow resource set names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V3.1.3
+- Don't allow empty names for ResourceSet
+
 V3.1.2
 - Fix passing Undefined to plugins in templates
 

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -601,7 +601,7 @@ entity ResourceSet:
 
     :attr name: The name of the resource set.
     """
-    string name
+    non_empty_string name
 end
 
 ResourceSet.resources [0:] -- std::Resource

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -594,6 +594,11 @@ implementation pkgs for Packages:
     end
 end
 
+typedef resource_set_name as string matching self != ""
+"""
+    A string that contains at least one character.
+"""
+
 entity ResourceSet:
     """
     A ResourceSet describes resources that logically belong together,
@@ -601,7 +606,7 @@ entity ResourceSet:
 
     :attr name: The name of the resource set.
     """
-    non_empty_string name
+    resource_set_name name
 end
 
 ResourceSet.resources [0:] -- std::Resource

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -594,11 +594,6 @@ implementation pkgs for Packages:
     end
 end
 
-typedef resource_set_name as string matching self != ""
-"""
-    A string that contains at least one character.
-"""
-
 entity ResourceSet:
     """
     A ResourceSet describes resources that logically belong together,
@@ -606,7 +601,7 @@ entity ResourceSet:
 
     :attr name: The name of the resource set.
     """
-    resource_set_name name
+    non_empty_string name
 end
 
 ResourceSet.resources [0:] -- std::Resource

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 3.1.2
+version: 3.1.3.dev1655890629
 compiler_version: 2020.8


### PR DESCRIPTION
# Description

This was not explicitly planned but the concern was [raised in the partial export PR](https://github.com/inmanta/inmanta-core/pull/4348#discussion_r902407757) that it might be better to disallow `""` as a resource set name. This PR is a bit more strict in that it doesn't allow any name with only whitespace characters, partially to be able to reuse the existing type, partially because it makes sense to have at least one visible character in the name.

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://internal.inmanta.com/developer/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
