### PR TITLE
Remove support for leaving nullable attribute unassigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V4.0.0
+- Remove support for leaving nullable attribute unassigned
+
 V3.1.3
 - Don't allow empty names for ResourceSet
 

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -475,7 +475,7 @@ entity AgentConfig extends PurgeableResource:
                         * retry_wait: The time to wait between retries for the remote target to become available. The default wait is 30s.
                    Example: ssh://centos@centos-machine/?python=python3 (This would connect to a the centos machine and use python3 as it's interpreter)
     """
-    bool? autostart
+    bool? autostart = null
     config_agent agentname
     string agent="internal"
     string uri="local:"
@@ -514,7 +514,7 @@ use relations to create a mutuable set of strings.
     a.string_list += std::MutableString(value="value1")
     a.string_list += std::MutableString(value="value2")
 """
-  string? value
+  string? value = null
 end
 
 implement MutableString using std::none
@@ -547,7 +547,7 @@ use relations to create a mutuable set of numbers.
     a.string_list += std::MutableNumber(value=3)
     a.string_list += std::MutableNumber(value=7)
 """
-  number? value
+  number? value = null
 end
 
 implement MutableNumber using std::none
@@ -568,7 +568,7 @@ Wrapper for boolean values, used to pass a boolean out of an if statement.
     end
 
 """
-  bool? value
+  bool? value = null
 end
 
 implement MutableBool using std::none

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 3.1.5
+version: 4.0.0.dev1664977727
 compiler_version: 2020.8


### PR DESCRIPTION
# Description

make sure optional variables are always assigned a value.

closes https://github.com/inmanta/inmanta-core/issues/1888

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://internal.inmanta.com/developer/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
