### PR TITLE
[FIX] drop broken is_set plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V4.0.1
+- Drop is_set plugin
+
 V4.0.0
 - autostart attribute of AgentConfig doesn't allow null as value anymore
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 4.0.0
+version: 4.0.1.dev1666779624
 compiler_version: 2020.8

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -835,15 +835,6 @@ def environment_server(ctx: Context) -> "string":
 
 
 @plugin
-def is_set(obj: "any", attribute: "string") -> "bool":
-    try:
-        getattr(obj, attribute)
-    except Exception:
-        return False
-    return True
-
-
-@plugin
 def server_ca() -> "string":
     filename = Config.get("compiler_rest_transport", "ssl_ca_cert_file", None)
     if not filename:


### PR DESCRIPTION
# Description
Drop the is_set plugin which was broken.

closes #384 

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://internal.inmanta.com/developer/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
