### PR TITLE
[FIX] bump inmanta-dev-dependencies version to 1.76.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V2.1.14
+- Bump dev dependencies
+
 V2.1.13
 - Fix tests to support email_validator>=1.2.0 (backport of v3.0.16)
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 2.1.13
+version: 2.1.14.dev1669035445
 compiler_version: 2020.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-inmanta-dev-dependencies[module]==1.34.0
+inmanta-dev-dependencies[module]==1.76.0
 wheel==0.37.0
 pytest-inmanta<1.7.0.dev
 inmanta-core~=4.4.0 # This is the iso4 branch, force correct core for tests


### PR DESCRIPTION
# Description

Build https://jenkins.inmanta.com/job/modules/job/std/job/iso4/195/ was failing because black version 20.8b1 is not compatible with python > 3.9.7

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://internal.inmanta.com/developer/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
