### PR TITLE
Improve error logging in std::Package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v4.1.1 
+## v4.1.1 - ?
 - Improve error logging in std::Package
 
 ## v4.1.0 - 2023-01-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+V4.0.2
+- Improve error logging in std::Package
+
 V4.0.1
 - Drop is_set plugin
 

--- a/plugins/resources.py
+++ b/plugins/resources.py
@@ -460,9 +460,9 @@ class YumPackage(ResourceHandler):
     def _run_yum(self, args):
         # todo: cache value
         if self._io.file_exists("/usr/bin/dnf"):
-            return self._io.run("/usr/bin/dnf", ["-v", "-y"] + args)
+            return self._io.run("/usr/bin/dnf", ["-d", "0", "-e", "1", "-y"] + args)
         else:
-            return self._io.run("/usr/bin/yum", ["-v", "-y"] + args)
+            return self._io.run("/usr/bin/yum", ["-d", "0", "-e", "1", "-y"] + args)
 
     def check_resource(self, ctx, resource):
         yum_output = self._run_yum(["info", resource.name])

--- a/plugins/resources.py
+++ b/plugins/resources.py
@@ -460,9 +460,9 @@ class YumPackage(ResourceHandler):
     def _run_yum(self, args):
         # todo: cache value
         if self._io.file_exists("/usr/bin/dnf"):
-            return self._io.run("/usr/bin/dnf", ["-d", "0", "-e", "0", "-y"] + args)
+            return self._io.run("/usr/bin/dnf", ["-v", "-y"] + args)
         else:
-            return self._io.run("/usr/bin/yum", ["-d", "0", "-e", "0", "-y"] + args)
+            return self._io.run("/usr/bin/yum", ["-v", "-y"] + args)
 
     def check_resource(self, ctx, resource):
         yum_output = self._run_yum(["info", resource.name])


### PR DESCRIPTION
# Description

The handler for the std::Package discards error messages by providing the options `-d 0 -e 0` to dnf or yum. These flags have been deprecated and replaced with the `-v` flag (--verbose).

closes #238 

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://internal.inmanta.com/developer/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Version number is bumped to dev version
~~- [ ] Code is clear and sufficiently documented~~
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
~~- [ ] Correct, in line with design~~
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

