### PR TITLE
Added NullResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v4.1.4 - ?
-
+- Add std::testing::NullResource, the resource that does nothing
 
 ## v4.1.3 - 2023-02-02
 

--- a/plugins/resources.py
+++ b/plugins/resources.py
@@ -31,6 +31,7 @@ from inmanta.agent.handler import (
 from inmanta.execute.util import Unknown
 from inmanta.resources import (
     IgnoreResourceException,
+    ManagedResource,
     PurgeableResource,
     Resource,
     ResourceNotFoundExcpetion,
@@ -136,6 +137,12 @@ class Symlink(PurgeableResource):
     fields = ("source", "target", "reload")
 
 
+@resource("std::testing::NullResource", agent="agentname", id_attribute="name")
+class Null(ManagedResource, PurgeableResource):
+
+    fields = ("name", "agentname")
+
+
 @resource("std::AgentConfig", agent="agent", id_attribute="agentname")
 class AgentConfig(PurgeableResource):
     """
@@ -153,6 +160,25 @@ class AgentConfig(PurgeableResource):
             # When this attribute is not set, also ignore it
             raise IgnoreResourceException()
         return obj.autostart
+
+
+@provider("std::testing::NullResource", name="null")
+class NullProvider(CRUDHandler):
+    """Does nothing at all"""
+
+    def read_resource(self, ctx: HandlerContext, resource: PurgeableResource) -> None:
+        return
+
+    def create_resource(self, ctx: HandlerContext, resource: PurgeableResource) -> None:
+        ctx.set_created()
+
+    def delete_resource(self, ctx: HandlerContext, resource: PurgeableResource) -> None:
+        ctx.set_deleted()
+
+    def update_resource(
+        self, ctx: HandlerContext, changes: dict, resource: PurgeableResource
+    ) -> None:
+        ctx.set_updated()
 
 
 @provider("std::File", name="posix_file")

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -522,3 +522,17 @@ svc = std::Package(host=host, name="asdasdasd", state="installed")
         "Yum failed: stdout: errout: Error: Unable to find a match: asdasdasd"
         in ctx.logs[0].msg
     )
+
+
+def test_null_resource(project):
+    project.compile(
+        """
+            import std::testing
+
+            std::testing::NullResource()
+
+            std::testing::NullResource(agentname="testx", name="aaa")
+        """
+    )
+    project.deploy_resource("std::testing::NullResource", name="null")
+    project.deploy_resource("std::testing::NullResource", name="aaa")


### PR DESCRIPTION
# Description

Added a resource that does nothing, for testing and demo purposes

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

