### PR TITLE
fixed bug in delete action of std::testing::NullResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v4.1.5 - ?
-
+- Fixed bug in delete operation of std::testing::NullResource
 
 ## v4.1.4 - 2023-03-06
 - Add std::testing::NullResource, the resource that does nothing

--- a/plugins/resources.py
+++ b/plugins/resources.py
@@ -174,7 +174,7 @@ class NullProvider(CRUDHandler):
         ctx.set_created()
 
     def delete_resource(self, ctx: HandlerContext, resource: PurgeableResource) -> None:
-        ctx.set_deleted()
+        ctx.set_purged()
 
     def update_resource(
         self, ctx: HandlerContext, changes: dict, resource: PurgeableResource

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -535,6 +535,9 @@ def test_null_resource(project):
             std::testing::NullResource(agentname="testx", name="aaa")
 
             std::testing::NullResource(agentname="testx", name="bbb", fail=true)
+
+
+            std::testing::NullResource(agentname="p", name="p", purged=true)
         """
     )
     project.deploy_resource("std::testing::NullResource", name="null")
@@ -544,3 +547,4 @@ def test_null_resource(project):
         name="bbb",
         status=inmanta.const.ResourceState.failed,
     )
+    project.deploy_resource("std::testing::NullResource", name="p")


### PR DESCRIPTION
# Description

Fixed bug in std::testing::NullResource

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

