### PR TITLE
convert ~= requirements to >=

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-Jinja2~=3.1
-email_validator~=2.0
-pydantic~=1.10
-
-dataclasses~=0.7;python_version<'3.7'
+# explicitly use >=,< rather than ~= to force dependabot to widen constraints even though this is conventionally a lock file
+Jinja2>=3.1,<4
+email_validator>=1.3,<2
+pydantic>=1.10,<2


### PR DESCRIPTION
# Description

Explicitly use >=,< rather than ~= to force dependabot to widen constraints even though this is conventionally a lock file where it would otherwise just increase the lower bound.

The specific issue this should solve is that dependabot bumped `email-validator` to `~=2.0` while core is still at `~=1.3`. With this change dependabot should now bump it to `>=1.3,<3` instead, which would be compatible with both the current core and the next one (which will have bumped the constraint).

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

