### PR TITLE
Add a regex string type for pydantic v1 and v2

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1074,11 +1074,6 @@ def validate_type(
             max_length: int = None
             curtail_length: int = None (Only verify the regex on the first curtail_length characters)
             regex: str = None          (The regex is verified via Pattern.match())
-        * pydantic.stricturl:
-            min_length: int = 1
-            max_length: int = 2 ** 16
-            tld_required: bool = True
-            allowed_schemes: Optional[Set[str]] = None
 
     Example usage:
 

--- a/plugins/types.py
+++ b/plugins/types.py
@@ -22,7 +22,11 @@ import pydantic
 
 
 def regex_string(regex: typing.Union[str, re.Pattern]) -> type:
-    """Build a regex constrained string that is both supported by pydantic v1 and v2"""
+    """Build a regex constrained string that is both supported by pydantic v1 and v2
+
+    :param regex: A regex string or compiler regex pattern
+    :return: A type that the current pydantic can use for validation
+    """
     try:
         # v2
         return typing.Annotated[

--- a/plugins/types.py
+++ b/plugins/types.py
@@ -1,0 +1,39 @@
+"""
+    Copyright 2023 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+import re
+import typing
+
+import pydantic
+
+
+def regex_string(regex: typing.Union[str, re.Pattern]) -> type:
+    """Build a regex constrained string that is both supported by pydantic v1 and v2"""
+    try:
+        # v2
+        return typing.Annotated[
+            str,
+            pydantic.AfterValidator(
+                pydantic.TypeAdapter(
+                    pydantic.constr(pattern=regex),
+                    config=pydantic.ConfigDict(regex_engine="python-re"),
+                ).validate_python
+            ),
+        ]
+    except AttributeError:
+        # v1
+        return pydantic.constr(regex=regex)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -131,22 +131,6 @@ def test_attribute_types(project, attr_type, value, is_valid):
             False,
             False,
         ),
-        (
-            "pydantic.stricturl",
-            "string",
-            '"http://test:8080"',
-            '{"tld_required": false}',
-            False,
-            True,
-        ),
-        (
-            "pydantic.stricturl",
-            "string",
-            '"http://test:8080"',
-            '{"tld_required": true}',
-            False,
-            False,
-        ),
         ("pydantic.constr", "string", "null", '{"regex": "^tst.*$"}', True, True),
         ("pydantic.constr", "string", "null", '{"regex": "^tst.*$"}', False, False),
         (


### PR DESCRIPTION
# Description

This adds a helper that can create a type for pydantic modules that supports python regex on pydantic v1 and v2

The return type is only correct on pydantic v1, on v2 it is `typing._AnnotatedAlias` but I do not like to use that one.

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

