### PR TITLE
Add len plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## v4.3.6 - ?
+## v4.4.0 - ?
 
+- Add len plugin to get the length of a list, conservative with respect to unknowns
 
 ## v4.3.5 - 2023-11-21
 
 - Add ``regex_string`` function
-
 
 ## v4.3.4 - 2023-11-10
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 4.3.6.dev0
+version: 4.4.0.dev0
 compiler_version: 2020.8

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -575,9 +575,22 @@ def objid(value: "any") -> "string":
 @plugin
 def count(item_list: "list") -> "int":
     """
-    Returns the number of elements in this list
+    Returns the number of elements in this list.
+
+    If any unknowns are present in the list, counts them like any other value. Depending on the unknown semantics in your
+    model this may produce an inaccurate count. For a count that is conservative with respect to unknowns, see `len`.
     """
     return len(item_list)
+
+
+@plugin
+def len(item_list: "list") -> "int":
+    """
+    Returns the number of elements in this list. Unlike `count`, this plugin is conservative when it comes to unknown values.
+    If any unknown is present in the list, the result is also unknown.
+    """
+    unknown: Optional[Unknown] = next(item for item in item_list if isinstance(item, Unknown), None)
+    return len(item_list) if unknown is None else Unknown(source=unknown.source)
 
 
 @plugin

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -155,3 +155,33 @@ def test_string_plugins(project):
         c = "Aabb c"
         """
     )
+
+
+def test_len(project) -> None:
+    """
+    Verify the behavior of the len plugin and constrast it with the count plugin.
+    """
+    project.compile(
+        """
+        unknown = std::get_env_int("UNKNOWN_ENV_INT")
+
+        empty_list = []
+        non_empty_list = [1, 2]
+        unknown_list = [1, unknown, 2]
+        two_unknowns_list = [1, unknown, 2, unknown]
+
+        assert = true
+
+        assert = std::count(empty_list) == 0
+        assert = std::len(empty_list) == 0
+
+        assert = std::count(non_empty_list) == 2
+        assert = std::len(non_empty_list) == 2
+
+        assert = std::count(unknown_list) == 3
+        assert = std::is_unknown(std::len(unknown_list))
+
+        assert = std::count(two_unknowns_list) == 4
+        assert = std::is_unknown(std::len(two_unknowns_list))
+        """,
+    )


### PR DESCRIPTION
# Description

Adds the `len` plugin, like `count` but conservative with respect to unknowns.

closes #433

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

