### PR TITLE
Add support to deploy agentConfig for std::Host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v4.4.1 - ?
+## v4.5.0 - ?
 
+- Add support to deploy an agentConfig for std::Host
 
 ## v4.4.0 - 2023-12-05
 

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -461,6 +461,7 @@ implementation agentConfig for HostConfig:
 end
 
 Host.host_config [1] -- HostConfig.host [1]
+implement HostConfig using std::none
 implement HostConfig using agentConfig when host.ip is defined and host.remote_agent
 
 implementation hostDefaults for std::Host:

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -455,7 +455,7 @@ implementation agentConfig for HostConfig:
     std::AgentConfig(
         autostart=true,
         agentname=host.name,
-        uri=std::template("ip/host_uri.j2"),
+        uri=std::template("std/host_uri.j2"),
         provides=host,
     )
 end

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -145,7 +145,7 @@ typedef non_empty_string as string matching /^(.*\S.*)$/
     A string that contains at least one non-whitespace character
 """
 
-typedef port as number matching self >= 0 and self < 65536
+typedef port as int matching self >= 0 and self < 65536
 """
     A TCP/UDP port number.
 """

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -462,7 +462,7 @@ end
 
 Host.host_config [1] -- HostConfig.host [1]
 implement HostConfig using std::none
-implement HostConfig using agentConfig when host.ip is defined and host.remote_agent
+implement HostConfig using agentConfig when host.ip != null and host.remote_agent
 
 implementation hostDefaults for std::Host:
     HostConfig(host=self)

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -145,6 +145,11 @@ typedef non_empty_string as string matching /^(.*\S.*)$/
     A string that contains at least one non-whitespace character
 """
 
+typedef port as number matching self >= 0 and self < 65536
+"""
+    A TCP/UDP port number.
+"""
+
 implementation none for Entity:
     """
         An empty implementation that can be used as a safe default.
@@ -203,8 +208,18 @@ end
 
 entity Host extends ManagedDevice:
     """
-        A host models a server of computer in the managed infrastructure
+        A host models a server or computer in the managed infrastructure that
+        has an ip address.
+
+        :attr ip: The ipaddress of this node.
+        :attr remote_agent: Start the mgmt agent for this node on the server and use remote io (ssh).
+        :attr remote_user: The remote user for the remote agent to login with.
+        :attr remote_port: The remote port for this remote agent to use.
     """
+    ipv_any_address? ip = null
+    bool remote_agent=false
+    string remote_user="root"
+    port remote_port=22
 end
 
 implement Host using hostDefaults
@@ -436,9 +451,17 @@ entity HostConfig:
     """
 end
 
-Host.host_config [1] -- HostConfig.host [1]
-implement HostConfig using std::none
+implementation agentConfig for HostConfig:
+    std::AgentConfig(
+        autostart=true,
+        agentname=host.name,
+        uri=std::template("ip/host_uri.j2"),
+        provides=host,
+    )
+end
 
+Host.host_config [1] -- HostConfig.host [1]
+implement HostConfig using agentConfig when host.ip is defined and host.remote_agent
 
 implementation hostDefaults for std::Host:
     HostConfig(host=self)

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 4.4.1.dev0
+version: 4.5.0.dev0
 compiler_version: 2020.8

--- a/templates/host_uri.j2
+++ b/templates/host_uri.j2
@@ -1,0 +1,1 @@
+ssh://{{host.remote_user}}@{{host.ip}}:{{host.remote_port}}{% if host.os.python_cmd %}?python={{ host.os.python_cmd }}{% endif %}

--- a/tests/test_agentconfig.py
+++ b/tests/test_agentconfig.py
@@ -21,9 +21,9 @@ from inmanta.module import Project
 def test_agent_config(project: Project):
     project.compile(
         """
-        import ip
+        import std
 
-        host = ip::Host(
+        host = std::Host(
             name="test",
             ip="127.0.0.1",
             os=std::linux,
@@ -35,9 +35,9 @@ def test_agent_config(project: Project):
 
     project.compile(
         """
-        import ip
+        import std
 
-        host = ip::Host(
+        host = std::Host(
             name="test",
             ip="127.0.0.1",
             os=std::linux,
@@ -52,9 +52,9 @@ def test_agent_config(project: Project):
 
     project.compile(
         """
-        import ip
+        import std
 
-        host = ip::Host(
+        host = std::Host(
             name="test",
             ip="127.0.0.1",
             os=std::OS(name="testos", family=std::unix, python_cmd="test"),

--- a/tests/test_agentconfig.py
+++ b/tests/test_agentconfig.py
@@ -1,0 +1,68 @@
+"""
+    Copyright 2023 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+from inmanta.module import Project
+
+
+def test_agent_config(project: Project):
+    project.compile(
+        """
+        import ip
+
+        host = ip::Host(
+            name="test",
+            ip="127.0.0.1",
+            os=std::linux,
+        )
+    """
+    )
+    agent_config = project.get_resource("std::AgentConfig")
+    assert not agent_config
+
+    project.compile(
+        """
+        import ip
+
+        host = ip::Host(
+            name="test",
+            ip="127.0.0.1",
+            os=std::linux,
+            remote_agent=true,
+        )
+    """
+    )
+
+    agent_config = project.get_resource("std::AgentConfig")
+    assert agent_config
+    assert agent_config.uri == "ssh://root@127.0.0.1:22?python=python"
+
+    project.compile(
+        """
+        import ip
+
+        host = ip::Host(
+            name="test",
+            ip="127.0.0.1",
+            os=std::OS(name="testos", family=std::unix, python_cmd="test"),
+            remote_agent=true,
+        )
+    """
+    )
+
+    agent_config = project.get_resource("std::AgentConfig")
+    assert agent_config
+    assert agent_config.uri == "ssh://root@127.0.0.1:22?python=test"


### PR DESCRIPTION
# Description

Add support to deploy an `agentConfig` for `std::Host`.

closes #376 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

