### PR TITLE
remove todos from doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v5.1.1 - ?
 
+- remove a todo from the docs
 
 ## v5.1.0 - 2024-01-16
 

--- a/plugins/resources.py
+++ b/plugins/resources.py
@@ -581,8 +581,6 @@ class YumPackage(ResourceHandler):
 class DirectoryHandler(CRUDHandler):
     """
     A handler for creating directories
-
-    TODO: add recursive operations
     """
 
     def read_resource(self, ctx: HandlerContext, resource: PurgeableResource) -> None:


### PR DESCRIPTION
# Description

remove a Todo from the docs

follow up issue: https://app.zenhub.com/workspaces/core-5a7c152b04a1652024289b7b/issues/gh/inmanta/std/504
part of https://github.com/inmanta/inmanta-core/issues/7134

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

