### PR TITLE
Remove number type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - Remove usage of number type
 
+### Upgrade procedure
+- `std::to_number` plugin has been removed
+  - Numbers can be converted into a float by using `float(value)`
+  - Numbers can be converted into an integer by using `int(value)`
+- `std::OS.version` needs to be converted to a float
+- `std::MutableNumber` entity has been removed, new alternatives are available:
+  - `std::MutableInt` can be used for mutable integer
+  - `std::MutableFloat` can be used for mutable float
+
 ## v6.1.0 - 2024-10-07
 - Add ``receive_events`` attribute to ``std::Resource``
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1073,15 +1073,6 @@ def invert(value: "bool") -> "bool":
     return not value
 
 
-@deprecated
-@plugin
-def to_number(value: "any") -> "number":
-    """
-    Convert a value to a number
-    """
-    return int(value)
-
-
 @plugin
 def list_files(ctx: Context, path: "string") -> "list":
     """


### PR DESCRIPTION
# Description

One plugin still using the number type.

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. Wait for tests to pass
3. Add the tag and push it back


```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
4. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

