### PR TITLE
Fix compatibility with iso8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v7.0.1 - ?
 
-- The std::AgentConfig handler will act as a no-op when running against an ISO or OSS version that doesn't have the autostart_on_start environment configuration option anymore
+- The std::AgentConfig handler will act as a no-op when running against an ISO or OSS version that doesn't have the autostart_on_start environment configuration option anymore. It's recommanded to no longer use this resource in that case.
 
 ## v7.0.0 - 2024-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v7.0.1 - ?
 
-- The std::AgentConfig handler will act as a no-op when running against an ISO or OSS version that doesn't have the autostart_on_start environment configuration option anymore. It's recommanded to no longer use this resource in that case.
+- The std::AgentConfig handler will act as a no-op when running against an ISO or OSS version that doesn't have the autostart_agent_map environment configuration option anymore. It's recommanded to no longer use this resource in that case.
 
 ## v7.0.0 - 2024-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v7.0.1 - ?
 
+- The std::AgentConfig handler will act as a no-op when running against an ISO or OSS version that doesn't have the autostart_on_start environment configuration option anymore
 
 ## v7.0.0 - 2024-10-14
 

--- a/plugins/resources.py
+++ b/plugins/resources.py
@@ -104,6 +104,11 @@ class AgentConfigHandler(CRUDHandler):
 
     def read_resource(self, ctx: HandlerContext, resource: AgentConfig) -> None:
         if not self.has_autostarted_agent_map:
+            ctx.info(
+                msg="Running against a version of the Inmanta server that doesn't have the"
+                    " the autostarted_agent_map configuration option anymore. Not making any"
+                    " changes. It's recommended to remove this resource from the configuration model."
+            )
             return
         agent_config = self._get_map()
         ctx.set("map", agent_config)

--- a/plugins/resources.py
+++ b/plugins/resources.py
@@ -106,8 +106,8 @@ class AgentConfigHandler(CRUDHandler):
         if not self.has_autostarted_agent_map:
             ctx.info(
                 msg="Not making any changes, because we are running against a version of the Inmanta server"
-                    " that doesn't have the the autostarted_agent_map configuration option anymore."
-                    " It's recommended to remove this resource from the configuration model."
+                " that doesn't have the the autostarted_agent_map configuration option anymore."
+                " It's recommended to remove this resource from the configuration model."
             )
             return
         agent_config = self._get_map()

--- a/plugins/resources.py
+++ b/plugins/resources.py
@@ -105,9 +105,9 @@ class AgentConfigHandler(CRUDHandler):
     def read_resource(self, ctx: HandlerContext, resource: AgentConfig) -> None:
         if not self.has_autostarted_agent_map:
             ctx.info(
-                msg="Running against a version of the Inmanta server that doesn't have the"
-                    " the autostarted_agent_map configuration option anymore. Not making any"
-                    " changes. It's recommended to remove this resource from the configuration model."
+                msg="Not making any changes, because we are running against a version of the Inmanta server"
+                    " that doesn't have the the autostarted_agent_map configuration option anymore."
+                    " It's recommended to remove this resource from the configuration model."
             )
             return
         agent_config = self._get_map()


### PR DESCRIPTION
# Description

This PR makes the `std::AgentConfig` handler act as a no-op when running against versions of the Inmanta orchestrator that don't have the `autostarted_agent_map` configuration option anymore.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
