### PR TITLE
Issue/rework getenv plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v8.2.4 - ?
+## v8.3.0 - ?
 
+- Deprecate get_env_int plugin in favor of int(get_env())
 
 ## v8.2.3 - 2025-02-06
 
@@ -20,7 +21,6 @@
 
 ## v8.1.0 - 2025-01-16
 
-- Add getenv, getenv_or_unknown and getenv_or_raise plugins
 - Add json serialization and deserialization plugins
 
 ## v8.0.0 - 2024-12-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v8.3.0 - ?
 
+- Log warning when environment variable is not found by get_env plugin
 - Deprecate get_env_int plugin in favor of int(get_env())
 
 ## v8.2.3 - 2025-02-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v8.0.1 - ?
+## v8.1.0 - ?
 
+- Add getenv, getenv_or_unknown and getenv_or_raise plugins
 
 ## v8.0.0 - 2024-12-12
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 8.0.1.dev0
+version: 8.1.0.dev0
 compiler_version: 2023.6

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: std
-version: 8.2.4.dev0
+version: 8.3.0.dev0
 compiler_version: 2023.6

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -41,12 +41,7 @@ from jinja2.runtime import Undefined, missing
 # don't bind to `resources` because this package has a submodule named resources that will bind to `resources` when imported
 import inmanta.resources
 from inmanta import util
-from inmanta.ast import (
-    NotFoundException,
-    OptionalValueException,
-    PluginException,
-    RuntimeException,
-)
+from inmanta.ast import NotFoundException, OptionalValueException, RuntimeException
 from inmanta.config import Config
 from inmanta.execute.proxy import DynamicProxy, UnknownException
 from inmanta.execute.util import NoneValue, Unknown

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -971,16 +971,64 @@ def server_port() -> "int":
 
 
 @plugin
+def getenv(key: "string", default: "string?" = None) -> "string?":
+    """
+    Get an environment variable, return None if it doesn't exist.
+    The optional second argument can specify an alternate default.
+
+    Equivalent to python's os.getenv
+
+    :param key: The name of the environment variable to get
+    :param default: The default value to return if the environment variable
+        is not set.
+    """
+    return os.getenv(key, default)
+
+
+@plugin
+def getenv_or_unknown(key: "string") -> "string":
+    """
+    Get an environment variable, return Unknown if it doesn't exist.
+    Also log a warning to show the missing environment variable.
+
+    :param key: The name of the environment variable to get
+    """
+    val = getenv(key)
+    if val is not None:
+        return val
+
+    logging.getLogger(__name__).warning(
+        "Environment variable %s doesn't exist, returning Unknown(source=%s) instead",
+        key,
+        repr(key),
+    )
+    return Unknown(source=key)
+
+
+@plugin
+def getenv_or_raise(key: "string") -> "string":
+    """
+    Get an environment variable, raise a LookupError if it doesn't exist.
+
+    :param key: The name of the environment variable to get
+    """
+    val = getenv(key)
+    if val is not None:
+        return val
+
+    raise LookupError(f"Environment variable {key} doesn't exist")
+
+
+@deprecated(replaced_by="std::getenv(...) or std::getenv_or_unknown(...)")
+@plugin
 def get_env(name: "string", default_value: "string" = None) -> "string":
-    env = os.environ
-    if name in env:
-        return env[name]
-    elif default_value is not None:
-        return default_value
+    if default_value is None:
+        return getenv_or_unknown(name)
     else:
-        return Unknown(source=name)
+        return getenv(name, default_value)
 
 
+@deprecated(replaced_by="int(std::getenv(...)) or int(std::getenv_or_unknown(...))")
 @plugin
 def get_env_int(name: "string", default_value: "int" = None) -> "int":
     env = os.environ

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -39,7 +39,12 @@ from jinja2.runtime import Undefined, missing
 
 # don't bind to `resources` because this package has a submodule named resources that will bind to `resources` when imported
 import inmanta.resources
-from inmanta.ast import NotFoundException, OptionalValueException, RuntimeException
+from inmanta.ast import (
+    NotFoundException,
+    OptionalValueException,
+    PluginException,
+    RuntimeException,
+)
 from inmanta.config import Config
 from inmanta.execute.proxy import DynamicProxy, UnknownException
 from inmanta.execute.util import NoneValue, Unknown
@@ -1016,7 +1021,7 @@ def getenv_or_raise(key: "string") -> "string":
     if val is not None:
         return val
 
-    raise LookupError(f"Environment variable {key} doesn't exist")
+    raise PluginException(f"Environment variable {key} doesn't exist")
 
 
 @deprecated(replaced_by="std::getenv(...) or std::getenv_or_unknown(...)")

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -998,7 +998,7 @@ def getenv_or_unknown(key: "string") -> "string":
 
     :param key: The name of the environment variable to get
     """
-    val = getenv(key)
+    val = os.getenv(key)
     if val is not None:
         return val
 
@@ -1017,32 +1017,43 @@ def getenv_or_raise(key: "string") -> "string":
 
     :param key: The name of the environment variable to get
     """
-    val = getenv(key)
+    val = os.getenv(key)
     if val is not None:
         return val
 
     raise PluginException(f"Environment variable {key} doesn't exist")
 
 
-@deprecated(replaced_by="std::getenv(...) or std::getenv_or_unknown(...)")
 @plugin
-def get_env(name: "string", default_value: "string" = None) -> "string":
-    if default_value is None:
-        return getenv_or_unknown(name)
-    else:
-        return getenv(name, default_value)
+def get_env(name: "string", default_value: "string?" = None) -> "string":
+    # This plugin will remain, but it is recommended to use getenv and getenv_or_unknown
+    # instead
+    val = os.getenv(name, default_value)
+    if val is not None:
+        return val
+
+    logging.getLogger(__name__).warning(
+        "Environment variable %s doesn't exist, returning Unknown(source=%s) instead",
+        name,
+        repr(name),
+    )
+    return Unknown(source=name)
 
 
-@deprecated(replaced_by="int(std::getenv(...)) or int(std::getenv_or_unknown(...))")
 @plugin
-def get_env_int(name: "string", default_value: "int" = None) -> "int":
-    env = os.environ
-    if name in env:
-        return int(env[name])
-    elif default_value is not None:
-        return default_value
-    else:
-        return Unknown(source=name)
+def get_env_int(name: "string", default_value: "int?" = None) -> "int":
+    # This plugin will remain, but it is recommended to use getenv and getenv_or_unknown
+    # instead
+    val: str | int | None = os.getenv(name, default_value)
+    if val is not None:
+        return int(val)
+
+    logging.getLogger(__name__).warning(
+        "Environment variable %s doesn't exist, returning Unknown(source=%s) instead",
+        name,
+        repr(name),
+    )
+    return Unknown(source=name)
 
 
 @plugin

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -978,58 +978,13 @@ def server_port() -> "int":
 
 
 @plugin
-def getenv(key: "string", default: "string?" = None) -> "string?":
-    """
-    Get an environment variable, return None if it doesn't exist.
-    The optional second argument can specify an alternate default.
-
-    Equivalent to python's os.getenv
-
-    :param key: The name of the environment variable to get
-    :param default: The default value to return if the environment variable
-        is not set.
-    """
-    return os.getenv(key, default)
-
-
-@plugin
-def getenv_or_unknown(key: "string") -> "string":
+def get_env(name: "string", default_value: "string?" = None) -> "string":
     """
     Get an environment variable, return Unknown if it doesn't exist.
     Also log a warning to show the missing environment variable.
 
     :param key: The name of the environment variable to get
     """
-    val = os.getenv(key)
-    if val is not None:
-        return val
-
-    logging.getLogger(__name__).warning(
-        "Environment variable %s doesn't exist, returning Unknown(source=%s) instead",
-        key,
-        repr(key),
-    )
-    return Unknown(source=key)
-
-
-@plugin
-def getenv_or_raise(key: "string") -> "string":
-    """
-    Get an environment variable, raise a LookupError if it doesn't exist.
-
-    :param key: The name of the environment variable to get
-    """
-    val = os.getenv(key)
-    if val is not None:
-        return val
-
-    raise PluginException(f"Environment variable {key} doesn't exist")
-
-
-@plugin
-def get_env(name: "string", default_value: "string?" = None) -> "string":
-    # This plugin will remain, but it is recommended to use getenv and getenv_or_unknown
-    # instead
     val = os.getenv(name, default_value)
     if val is not None:
         return val
@@ -1042,9 +997,10 @@ def get_env(name: "string", default_value: "string?" = None) -> "string":
     return Unknown(source=name)
 
 
+@deprecated(replaced_by="int(std::get_env(...))")
 @plugin
 def get_env_int(name: "string", default_value: "int?" = None) -> "int":
-    # This plugin will remain, but it is recommended to use getenv and getenv_or_unknown
+    # This plugin will remain, but it is recommended to use getenv
     # instead
     val: str | int | None = os.getenv(name, default_value)
     if val is not None:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -21,7 +21,7 @@ import re
 import pytest
 from pytest_inmanta.plugin import Project
 
-from inmanta.ast import ExternalException
+import inmanta.ast
 
 
 def test_select_attr(project):
@@ -207,7 +207,7 @@ def test_json(project: Project) -> None:
     )
 
     # Entities can not be serialized
-    with pytest.raises(ExternalException) as exc_info:
+    with pytest.raises(inmanta.ast.ExternalException) as exc_info:
         project.compile(
             """
             entity A: end
@@ -215,7 +215,7 @@ def test_json(project: Project) -> None:
             """
         )
 
-    exc: ExternalException = exc_info.value
+    exc: inmanta.ast.ExternalException = exc_info.value
     assert re.match(
         r"@__config__::A [a-f0-9]+ is not JSON serializable",
         str(exc.__cause__),

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -21,7 +21,7 @@ import re
 import pytest
 from pytest_inmanta.plugin import Project
 
-from inmanta.ast import ExplicitPluginException, ExternalException
+from inmanta.ast import ExternalException
 
 
 def test_select_attr(project):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -169,7 +169,7 @@ def test_len(project) -> None:
     """
     project.compile(
         """
-        unknown = int(std::getenv("UNKNOWN_ENV_INT"))
+        unknown = int(std::get_env("UNKNOWN_ENV_INT"))
 
         empty_list = []
         non_empty_list = [1, 2]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -163,58 +163,13 @@ def test_string_plugins(project):
     )
 
 
-def test_getenv(project: Project, monkeypatch: pytest.MonkeyPatch) -> None:
-    """
-    Verify the good behavior of all getenv plugins
-    """
-    # Check that getenv_or_raise raises a plugin exception
-    with pytest.raises(
-        ExplicitPluginException,
-        match="Environment variable NOT_AN_ENV_VAR doesn't exist",
-    ):
-        project.compile("std::getenv_or_raise('NOT_AN_ENV_VAR')")
-
-    # Check that getenv_or_unknown returns an unknown
-    project.compile(
-        """
-        unknown = std::getenv_or_unknown('NOT_AN_ENV_VAR')
-
-        assert = true
-        assert = std::is_unknown(unknown)
-        """
-    )
-
-    # Check that getenv returns None or a default
-    project.compile(
-        """
-        none = std::getenv('NOT_AN_ENV_VAR')
-        none = null
-
-        def = std::getenv('NOT_AN_ENV_VAR', "def")
-        def = "def"
-        """
-    )
-
-    # Check that all getenv plugins return the env var when it is set
-    with monkeypatch.context() as ctx:
-        ctx.setenv("ENV_VAR", "val")
-        project.compile(
-            """
-            val = "val"
-            val = std::getenv("ENV_VAR")
-            val = std::getenv_or_unknown("ENV_VAR")
-            val = std::getenv_or_raise("ENV_VAR")
-            """
-        )
-
-
 def test_len(project) -> None:
     """
     Verify the behavior of the len plugin and contrast it with the count plugin.
     """
     project.compile(
         """
-        unknown = int(std::getenv_or_unknown("UNKNOWN_ENV_INT"))
+        unknown = int(std::getenv("UNKNOWN_ENV_INT"))
 
         empty_list = []
         non_empty_list = [1, 2]


### PR DESCRIPTION
# Description

**Context**  
When an env var is missing, the existing plugin will just return an Unknown, without any warning.  This can be very frustrating to troubleshoot.  

The purpose of this PR is multiple:
1. Make it easier to diagnose missing env vars (the existing plugins should log a warning message)
2. Align the plugin definition with python's `os.getenv` and make the behaviors deviating from the original more explicits, this design choice has not been discussed yet, it is open for debate

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. Wait for tests to pass
3. Add the tag and push it back


```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
4. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

