### PR TITLE
Issue/2025 02 18 bm disable systemd in container test iso7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v5.2.8 - ?
 
+- remove test
 
 ## v5.2.7 - 2024-10-07
 - Add ``receive_events`` attribute to ``std::Resource``

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -333,62 +333,6 @@ def systemd(project):
     systemd.clean()
 
 
-def test_systemd_service(project, systemd):
-    """
-    Test deploying systemd
-    """
-    # TODO: test reload
-    project.compile(
-        """
-import unittest
-
-host = std::Host(name="server", os=std::linux)
-svc = std::Service(host=host, name="test", state="running", onboot=true)
-"""
-    )
-
-    svc = project.get_resource("std::Service", name="test")
-    ctx = project.deploy(svc, run_as_root=False)
-    assert ctx.status == inmanta.const.ResourceState.deployed
-    assert ctx.change == inmanta.const.Change.updated
-
-    assert systemd.is_enabled()
-    assert systemd.is_active()
-
-    project.compile(
-        """
-import unittest
-
-host = std::Host(name="server", os=std::linux)
-svc = std::Service(host=host, name="test", state="stopped", onboot=true)
-"""
-    )
-
-    svc = project.get_resource("std::Service", name="test")
-    ctx = project.deploy(svc, run_as_root=False)
-    assert ctx.status == inmanta.const.ResourceState.deployed
-    assert ctx.change == inmanta.const.Change.updated
-
-    assert systemd.is_enabled()
-    assert not systemd.is_active()
-
-    project.compile(
-        """
-import unittest
-
-host = std::Host(name="server", os=std::linux)
-svc = std::Service(host=host, name="test", state="stopped", onboot=false)
-"""
-    )
-
-    svc = project.get_resource("std::Service", name="test")
-    ctx = project.deploy(svc, run_as_root=False)
-    assert ctx.status == inmanta.const.ResourceState.deployed
-    assert ctx.change == inmanta.const.Change.updated
-
-    assert not systemd.is_enabled()
-    assert not systemd.is_active()
-
 
 def test_issue_147(project, systemd):
     """

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -333,7 +333,6 @@ def systemd(project):
     systemd.clean()
 
 
-
 def test_issue_147(project, systemd):
     """
     A reload of a service should not start the service if it's not running.


### PR DESCRIPTION
# Description

Remove obsolete test:

- Testing systemd inside containers is not very well supported
- std::Service is only used internally and got removed fully in iso8

 should fix https://jenkins.inmanta.com/job/modules/job/module_sets/product=iso7,stream=dev/1682/console

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. Wait for tests to pass
3. Add the tag and push it back


```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
4. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

