### PR TITLE
Skip references tests on old core version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v8.3.1 - ?
 
+- Skip the tests for the references when running against an old version of inmanta-core that doesn't support references yet.
 
 ## v8.3.0 - 2025-03-12
 

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -16,9 +16,17 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import pytest
 from pytest_inmanta.plugin import Project
 
 from inmanta import const
+
+try:
+    from inmanta.references import Reference, reference  # noqa: F401
+except ImportError:
+    pytestmark = pytest.skip(
+        "Reference are not yet supported by this core version", allow_module_level=True
+    )
 
 
 def test_references_resource(project: Project, monkeypatch) -> None:


### PR DESCRIPTION
# Description

Skip the tests for the references when running against an old version of inmanta-core that doesn't support references yet.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~