### PR TITLE
Refactor jinja proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,3 @@ format:
 .PHONY: pep8
 pep8:
 	$(flake8)
-
-
-# TODO: remove
-.PHONY: pep8
-ci-pep8:
-	true

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,9 @@ format:
 .PHONY: pep8
 pep8:
 	$(flake8)
+
+
+# TODO: remove
+.PHONY: pep8
+ci-pep8:
+	true

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -78,7 +78,7 @@ def inmanta_reset_state() -> None:
 class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
     def __init__(self, instance: P, *, parent_context: Optional[typing.Never] = None) -> None:
         # TODO: mention why we don't pass parent_context
-        super().__init__(self, instance._get_instance())
+        super().__init__(instance._get_instance())
         object.__setattr__(self, "delegate", instance)
 
     def _get_delegate(self) -> P:

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -80,7 +80,7 @@ class JinjaProxyWrapper[P: proxy.DynamicProxy](ABC):
         object.__setattr__(self, "proxy", dynamic_proxy)
 
     def _get_proxy(self) -> P:
-        return object.__getattr__(self, "proxy")
+        return object.__getattribute__(self, "proxy")
 
     @classmethod
     def wrap(cls, value: object) -> object:
@@ -115,7 +115,7 @@ class JinjaProxyWrapper[P: proxy.DynamicProxy](ABC):
         return self._get_proxy() < other
 
     def __str__(self) -> str:
-        return repr(self._get_proxy())
+        return str(self._get_proxy())
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self._get_proxy!r})"

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -94,7 +94,8 @@ class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
         """
         Converts a value from the internal domain to the Jinja domain.
 
-        Core's DynamicProxy will not call this method. It is meant purely as a convenience method top-level conversion.
+        Core's DynamicProxy implementation will not call this method, even for subclasses of this one. It is meant purely as a
+        convenience method top-level conversion.
         """
         return cls.wrap(super().return_value(value))
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -133,7 +133,6 @@ class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
             try:
                 return self.wrap(getattr(self._get_delegate(), name))
             except (OptionalValueException, NotFoundException):
-                # TODO: create ticket. Should probably be StrictUndefined
                 return Undefined(
                     "variable %s not set on %s" % (name, instance),
                     instance,

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -75,23 +75,16 @@ def inmanta_reset_state() -> None:
 
 
 class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
-    def __init__(self, instance: P, *, parent_context: Optional[typing.Never] = None) -> None:
-        # TODO: mention why we don't pass parent_context
+    def __init__(self, instance: P) -> None:
         super().__init__(instance._get_instance())
         object.__setattr__(self, "delegate", instance)
 
     def _get_delegate(self) -> P:
         return object.__getattribute__(self, "delegate")
 
-    # TODO: add tests with references, including in lists etc
-    @classmethod
-    def _black_box(cls) -> bool:
-        return True
-
     # TODO: is this method useful or should it be dropped?
-    # TODO: mention why we don't use context
     @classmethod
-    def return_value(cls, value: object, *, context: Optional[typing.Never] = None) -> object:
+    def return_value(cls, value: object) -> object:
         return cls.wrap(super().return_value(value))
 
     @classmethod

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -74,7 +74,6 @@ def inmanta_reset_state() -> None:
     fact_cache = {}
 
 
-# TODO: reference validation
 class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
     def __init__(self, instance: P, *, parent_context: Optional[typing.Never] = None) -> None:
         # TODO: mention why we don't pass parent_context
@@ -83,6 +82,11 @@ class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
 
     def _get_delegate(self) -> P:
         return object.__getattribute__(self, "delegate")
+
+    # TODO: add tests with references, including in lists etc
+    @classmethod
+    def _black_box(cls) -> bool:
+        return True
 
     # TODO: is this method useful or should it be dropped?
     # TODO: mention why we don't use context
@@ -109,9 +113,8 @@ class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
                 return JinjaCallProxy(value)
             case proxy.DynamicProxy():
                 return JinjaDynamicProxy(value)
-            case _:
-                # TODO
-                raise Exception("not possible")
+            case _never:
+                typing.assert_never(_never)
 
     def __getattr__(self, name: str) -> object:
         instance = self._get_instance()
@@ -126,8 +129,7 @@ class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
                     name,
                 )
         else:
-            # TODO: refactor
-            # A native python object
+            # A native python object. Not supported by core's DynamicProxy
             return JinjaDynamicProxy.return_value(getattr(instance, name))
 
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -104,9 +104,7 @@ class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
         Wrap a value in a jinja-compatible proxy, if required.
         """
         return (
-            cls._wrap_proxy(value)
-            if isinstance(value, proxy.DynamicProxy)
-            else value
+            cls._wrap_proxy(value) if isinstance(value, proxy.DynamicProxy) else value
         )
 
     @classmethod
@@ -145,10 +143,13 @@ class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
             return JinjaDynamicProxy.return_value(getattr(instance, name))
 
 
-class JinjaGetItemproxy[K: int | str, P: proxy.SequenceProxy | proxy.DictProxy](JinjaDynamicProxy[P], ABC):
+class JinjaGetItemproxy[K: int | str, P: proxy.SequenceProxy | proxy.DictProxy](
+    JinjaDynamicProxy[P], ABC
+):
     """
     Jinja-compatible proxy for __getitem__.
     """
+
     def __getitem__(self, key: K) -> object:
         return self.wrap(self._get_delegate()[key])
 


### PR DESCRIPTION
# Description

Refactored std's Jinja DynamicProxy implementation to delegate to core, except for jinja-specific requirements.

This allows us to make changes to inmanta-core's dynamic proxy behavior without having to update the std module, and while keeping everything nicely back- and forward compatible.


note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. Wait for tests to pass
3. Add the tag and push it back


```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
4. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] ~~Changelog entry~~
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

