### PR TITLE
reference guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add int and fact reference
 - Set ``send_event=true`` by default because it's required for most practical models, and the recently introduced
     ``receive_events`` is a more appropriate setting for most other cases.
+- Reject reference values during Jinja template evaluation
+- Allow reference values for some basic plugins
 
 ## v8.4.2 - 2025-06-03
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -61,7 +61,7 @@ except ImportError:
     def ProxyContext(**kwargs: object) -> None:  # type: ignore
         return None
 
-    def allow_reference_values[T](instance: T) -> T:  # type: ignore
+    def allow_reference_values[T](instance: T) -> T:
         return instance
 
 
@@ -496,7 +496,7 @@ def password(context: Context, pw_id: "string") -> "string":
 
 
 @plugin("print")
-def printf(message: object | Reference[object]):
+def printf(message: object | Reference):
     """
     Print the given message to stdout
     """
@@ -637,8 +637,8 @@ def inlineif(conditional: "bool", a: "any", b: "any") -> "any":
 
 @plugin
 def at(
-    objects: Sequence[object | Reference[object]], index: "int"
-) -> object | Reference[object]:
+    objects: Sequence[object | Reference], index: "int"
+) -> object | Reference:
     """
     Get the item at index
     """
@@ -646,7 +646,7 @@ def at(
 
 
 @plugin
-def attr(obj: "any", attr: "string") -> object | Reference[object]:
+def attr(obj: "any", attr: "string") -> object | Reference:
     return getattr(allow_reference_values(obj), attr)
 
 
@@ -670,7 +670,7 @@ def objid(value: "any") -> "string":
 
 
 @plugin
-def count(item_list: Sequence[object | Reference[object]]) -> "int":
+def count(item_list: Sequence[object | Reference]) -> "int":
     """
     Returns the number of elements in this list.
 
@@ -681,7 +681,7 @@ def count(item_list: Sequence[object | Reference[object]]) -> "int":
 
 
 @plugin("len")
-def list_len(item_list: Sequence[object | Reference[object]]) -> "int":
+def list_len(item_list: Sequence[object | Reference]) -> "int":
     """
     Returns the number of elements in this list. Unlike `count`, this plugin is conservative when it comes to unknown values.
     If any unknown is present in the list, the result is also unknown.
@@ -1120,9 +1120,9 @@ def contains(dct: "dict", key: "string") -> "bool":
 def getattribute(
     entity: "std::Entity",
     attribute_name: "string",
-    default_value: object | Reference[object] = None,
+    default_value: object | Reference = None,
     no_unknown: "bool" = True,
-) -> object | Reference[object]:
+) -> object | Reference:
     """
     Return the value of the given attribute. If the attribute does not exist, return the default value.
 
@@ -1157,7 +1157,7 @@ def list_files(ctx: Context, path: "string") -> "list":
 
 
 @plugin(allow_unknown=True)
-def is_unknown(value: object | Reference[object]) -> "bool":
+def is_unknown(value: object | Reference) -> "bool":
     return isinstance(value, Unknown)
 
 
@@ -1398,7 +1398,7 @@ try:
     class IntReference(Reference[int]):
         """A reference that converts a reference value to an int"""
 
-        def __init__(self, value: object | Reference[object]) -> None:
+        def __init__(self, value: object | Reference) -> None:
             """
             :param value: The reference or value to convert.
             """
@@ -1412,7 +1412,7 @@ try:
             return value
 
     @plugin
-    def create_int_reference(value: object | Reference[object]) -> Reference[object]:
+    def create_int_reference(value: object | Reference) -> Reference[int]:
         return IntReference(value)
 
     @reference("std::Environment")

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -52,7 +52,6 @@ from inmanta.module import Project
 from inmanta.plugins import Context, PluginException, deprecated, plugin
 from inmanta.protocol import endpoints
 
-
 try:
     from inmanta.execute.proxy import ProxyContext
     from inmanta.plugins import allow_reference_values
@@ -64,6 +63,7 @@ except ImportError:
     def allow_reference_values[T](instance: T) -> T:
         return instance
 
+
 class MockReference:
     """
     Reference backwards compatibility object for use in plugin type annotations. When annotated, acts as an alias for
@@ -72,6 +72,7 @@ class MockReference:
 
     def __class_getitem__(self, key: str) -> type[object]:
         return object
+
 
 try:
     from inmanta.references import Reference
@@ -121,7 +122,9 @@ class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
         return object.__getattribute__(self, "__delegate")
 
     @classmethod
-    def return_value(cls, value: object, *, context: Optional["proxy.ProxyContext"]) -> object:
+    def return_value(
+        cls, value: object, *, context: Optional["proxy.ProxyContext"]
+    ) -> object:
         """
         Converts a value from the internal domain to the Jinja domain.
 
@@ -214,7 +217,9 @@ class JinjaIteratorProxy(JinjaDynamicProxy[proxy.IteratorProxy]):
         return self.wrap(next(self._get_delegate()))
 
 
-class JinjaGetItemProxy[K: int | str, P: proxy.SequenceProxy | proxy.DictProxy](JinjaDynamicProxy[P]):
+class JinjaGetItemProxy[K: int | str, P: proxy.SequenceProxy | proxy.DictProxy](
+    JinjaDynamicProxy[P]
+):
     """
     Jinja-compatible proxy for __getitem__ (ABC).
     """
@@ -248,7 +253,9 @@ class JinjaCallProxy(JinjaDynamicProxy[proxy.CallProxy]):
 
     def __call__(self, *args: object, **kwargs: object):
         # inmanta-core's CallProxy does not call return_value => call it here
-        return self._return_value(self._get_delegate()(*args, **kwargs), relative_path="(...)")
+        return self._return_value(
+            self._get_delegate()(*args, **kwargs), relative_path="(...)"
+        )
 
 
 class ResolverContext(jinja2.runtime.Context):
@@ -256,7 +263,9 @@ class ResolverContext(jinja2.runtime.Context):
         resolver = self.parent["{{resolver"]
         try:
             raw = resolver.lookup(key)
-            return JinjaDynamicProxy.return_value(raw.get_value(), context=ProxyContext(path=key, validated=False))
+            return JinjaDynamicProxy.return_value(
+                raw.get_value(), context=ProxyContext(path=key, validated=False)
+            )
         except NotFoundException:
             return super(ResolverContext, self).resolve_or_missing(key)
         except OptionalValueException:
@@ -304,7 +313,9 @@ def _get_template_engine(ctx: Context) -> Environment:
         def curywrapper(name: str, func):
             def safewrapper(*args):
                 _raise_if_contains_undefined(args)
-                return JinjaDynamicProxy.return_value(func(*args), context=ProxyContext(path=name, validated=False))
+                return JinjaDynamicProxy.return_value(
+                    func(*args), context=ProxyContext(path=name, validated=False)
+                )
 
             return safewrapper
 
@@ -624,7 +635,9 @@ def inlineif(conditional: "bool", a: "any", b: "any") -> "any":
 
 
 @plugin
-def at(objects: Sequence[object | Reference[object]], index: "int") -> object | Reference[object]:
+def at(
+    objects: Sequence[object | Reference[object]], index: "int"
+) -> object | Reference[object]:
     """
     Get the item at index
     """

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -57,7 +57,7 @@ try:
     from inmanta.execute.proxy import ProxyContext
     from inmanta.plugins import allow_reference_values
 except ImportError:
-    # older inmanta-core versions don't support this yet => mock it to return None
+    # older inmanta-core versions (<16) don't support this yet => mock it to return None
     def ProxyContext(**kwargs: object) -> None:  # type: ignore
         return None
 
@@ -112,7 +112,7 @@ class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
         if hasattr(instance, "_get_context"):
             super().__init__(instance._get_instance(), context=instance._get_context())
         else:
-            # backwards compatibility for older inmanta-core versions
+            # backwards compatibility for older inmanta-core versions (<16)
             super().__init__(instance._get_instance())
         object.__setattr__(self, "__delegate", instance)
 
@@ -136,7 +136,7 @@ class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
             inmanta-core.
         """
         if context is None:
-            # backwards compatibility with older inmanta-core
+            # backwards compatibility with older inmanta-core (<16)
             return cls.wrap(super().return_value(value))
 
         # context was introduced after references

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -500,7 +500,11 @@ def printf(message: object | Reference):
     """
     Print the given message to stdout
     """
-    print(message)
+    if Reference is not MockReference and isinstance(message, Reference):
+        # Reference raises an error on __str__ so it can't be used accidentally.
+        print(repr(message))
+    else:
+        print(message)
 
 
 @plugin

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -640,9 +640,7 @@ def inlineif(conditional: "bool", a: "any", b: "any") -> "any":
 
 
 @plugin
-def at(
-    objects: Sequence[object | Reference], index: "int"
-) -> object | Reference:
+def at(objects: Sequence[object | Reference], index: "int") -> object | Reference:
     """
     Get the item at index
     """

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -145,7 +145,7 @@ class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
         # they are never rejected at runtime on the plugin boundary (core's normal operating mode).
         if isinstance(value, Reference):
             raise PluginException(
-                f"Encountered reference in Jinja template for variable {context.path} (= `{value}`)"
+                f"Encountered reference in Jinja template for variable {context.path} (= `{value!r}`)"
             )
 
         return cls.wrap(super().return_value(value, context=context))

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -28,9 +28,10 @@ import re
 import time
 import typing
 from collections import defaultdict
+from collections.abc import Iterator
 from itertools import chain
 from operator import attrgetter
-from typing import Any, Generic, Optional, Tuple, TypeVar
+from typing import Any, Optional, Tuple
 
 import jinja2
 import pydantic
@@ -48,8 +49,16 @@ from inmanta.execute import proxy
 from inmanta.execute.util import NoneValue, Unknown
 from inmanta.export import dependency_manager, unknown_parameters
 from inmanta.module import Project
-from inmanta.plugins import Context, deprecated, plugin
+from inmanta.plugins import Context, PluginException, deprecated, plugin
 from inmanta.protocol import endpoints
+
+
+try:
+    ProxyContext = proxy.ProxyContext
+except AttributeError:
+    # older inmanta-core versions don't support this yet => mock it to return None
+    def ProxyContext(**kwargs: object) -> None:
+        return None
 
 
 @plugin
@@ -74,33 +83,57 @@ def inmanta_reset_state() -> None:
     fact_cache = {}
 
 
-P = TypeVar("P", bound=proxy.DynamicProxy)
-
-
-class JinjaDynamicProxy(proxy.DynamicProxy, Generic[P]):
+class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
     """
     Dynamic proxy built on top of inmanta-core's DynamicProxy to provide Jinja-specific capabilities.
     """
 
     def __init__(self, instance: P) -> None:
-        super().__init__(instance._get_instance())
-        object.__setattr__(self, "delegate", instance)
+        if hasattr(instance, "_get_context"):
+            super().__init__(instance._get_instance(), context=instance._get_context())
+        else:
+            # backwards compatibility for older inmanta-core versions
+            super().__init__(instance._get_instance())
+        object.__setattr__(self, "__delegate", instance)
 
     def _get_delegate(self) -> P:
         """
         Get the normal proxy object backing this one.
         """
-        return object.__getattribute__(self, "delegate")
+        return object.__getattribute__(self, "__delegate")
 
     @classmethod
-    def return_value(cls, value: object) -> object:
+    def return_value(cls, value: object, *, context: Optional["proxy.ProxyContext"]) -> object:
         """
         Converts a value from the internal domain to the Jinja domain.
 
         Core's DynamicProxy implementation will not call this method, even for subclasses of this one. It is meant purely as a
         convenience method top-level conversion.
+
+        :param context: The proxy context. Must only be None if proxy.ProxyContext does not exist on the current version of
+            inmanta-core.
         """
-        return cls.wrap(super().return_value(value))
+        if context is None:
+            # backwards compatibility with older inmanta-core
+            return cls.wrap(super().return_value(value))
+
+        # context was introduced after references, so this is a safe import
+        from inmanta.references import Reference
+        # core's DynamicProxy takes care of references on-proxy. But we have to guard top-level references here because
+        # they are never rejected at runtime on the plugin boundary (core's normal operating mode).
+        if isinstance(value, Reference):
+            raise PluginException(
+                f"Encountered reference in Jinja template for variable {context.path} (= `{value}`)"
+            )
+
+        return cls.wrap(super().return_value(value, context=context))
+
+    def _return_value(self, value: object, *, relative_path: str) -> object:
+        delegate: proxy.DynamicProxy = self._get_delegate()
+        if hasattr(delegate, "_return_value"):
+            return self.wrap(delegate._return_value(value, relative_path=relative_path))
+        else:
+            return JinjaDynamicProxy.return_value(value)
 
     @classmethod
     def wrap(cls, value: object) -> object:
@@ -123,6 +156,8 @@ class JinjaDynamicProxy(proxy.DynamicProxy, Generic[P]):
                 return JinjaSequenceProxy(value)
             case proxy.DictProxy():
                 return JinjaDictProxy(value)
+            case proxy.IteratorProxy():
+                return JinjaIteratorProxy(value)
             case proxy.CallProxy():
                 return JinjaCallProxy(value)
             case proxy.DynamicProxy():
@@ -143,14 +178,25 @@ class JinjaDynamicProxy(proxy.DynamicProxy, Generic[P]):
                 )
         else:
             # A native python object. Not supported by core's DynamicProxy
-            return JinjaDynamicProxy.return_value(getattr(instance, name))
+            return self._return_value(getattr(instance, name), relative_path=f".{name}")
 
 
-K = TypeVar("K", bound=int | str)
-IP = TypeVar("SP", bound=proxy.SequenceProxy | proxy.DictProxy)
+class JinjaIteratorProxy(JinjaDynamicProxy[proxy.IteratorProxy]):
+    """
+    Jinja-compatible iterator proxy.
+    """
+
+    def _is_sequence(self) -> bool:
+        return self._get_delegate()._is_sequence()
+
+    def __iter__(self) -> Iterator[object]:
+        return self
+
+    def __next__(self) -> object:
+        return self.wrap(next(self._get_delegate()))
 
 
-class JinjaGetItemproxy(JinjaDynamicProxy[IP], Generic[K, IP]):
+class JinjaGetItemProxy[K: int | str, P: proxy.SequenceProxy | proxy.DictProxy](JinjaDynamicProxy[P]):
     """
     Jinja-compatible proxy for __getitem__ (ABC).
     """
@@ -159,19 +205,19 @@ class JinjaGetItemproxy(JinjaDynamicProxy[IP], Generic[K, IP]):
         return self.wrap(self._get_delegate()[key])
 
     def __iter__(self) -> object:
-        return (self.wrap(v) for v in self._get_delegate())
+        return self.wrap(iter(self._get_delegate()))
 
     def __len__(self) -> int:
         return len(self._get_delegate())
 
 
-class JinjaSequenceProxy(JinjaGetItemproxy[int, proxy.SequenceProxy]):
+class JinjaSequenceProxy(JinjaGetItemProxy[int, proxy.SequenceProxy]):
     """
     Jinja-compatible sequence proxy.
     """
 
 
-class JinjaDictProxy(JinjaGetItemproxy[str, proxy.DictProxy]):
+class JinjaDictProxy(JinjaGetItemProxy[str, proxy.DictProxy]):
     """
     Jinja-compatible dict proxy.
     """
@@ -184,7 +230,7 @@ class JinjaCallProxy(JinjaDynamicProxy[proxy.CallProxy]):
 
     def __call__(self, *args: object, **kwargs: object):
         # inmanta-core's CallProxy does not call return_value => call it here
-        return JinjaDynamicProxy.return_value(self._get_delegate()(*args, **kwargs))
+        return self._return_value(self._get_delegate()(*args, **kwargs), relative_path="(...)")
 
 
 class ResolverContext(jinja2.runtime.Context):
@@ -192,7 +238,7 @@ class ResolverContext(jinja2.runtime.Context):
         resolver = self.parent["{{resolver"]
         try:
             raw = resolver.lookup(key)
-            return JinjaDynamicProxy.return_value(raw.get_value())
+            return JinjaDynamicProxy.return_value(raw.get_value(), context=ProxyContext(path=key, validated=False))
         except NotFoundException:
             return super(ResolverContext, self).resolve_or_missing(key)
         except OptionalValueException:
@@ -237,14 +283,15 @@ def _get_template_engine(ctx: Context) -> Environment:
     # register all plugins as filters
     for name, cls in ctx.get_compiler().get_plugins().items():
 
-        def curywrapper(func):
+        def curywrapper(name: str, func):
             def safewrapper(*args):
                 _raise_if_contains_undefined(args)
-                return JinjaDynamicProxy.return_value(func(*args))
+                return JinjaDynamicProxy.return_value(func(*args), context=ProxyContext(path=name, validated=False))
 
             return safewrapper
 
-        env.filters[name.replace("::", ".")] = curywrapper(cls)
+        jinja_name: str = name.replace("::", ".")
+        env.filters[jinja_name] = curywrapper(jinja_name, cls)
 
     engine_cache = env
     return env
@@ -418,6 +465,7 @@ def password(context: Context, pw_id: "string") -> "string":
         raise Exception("Password %s does not exist in file %s" % (pw_id, pw_file))
 
 
+# TODO: | Reference
 @plugin("print")
 def printf(message: "any"):
     """
@@ -462,6 +510,7 @@ def select(objects: "list", attr: "string") -> "list":
     return [getattr(item, attr) for item in objects]
 
 
+# TODO: | Reference
 @plugin
 def item(objects: "list", index: "int") -> "list":
     """
@@ -474,6 +523,7 @@ def item(objects: "list", index: "int") -> "list":
     return r
 
 
+# TODO: | Reference
 @plugin
 def key_sort(items: "list", key: "any") -> "list":
     """
@@ -558,6 +608,7 @@ def inlineif(conditional: "bool", a: "any", b: "any") -> "any":
     return b
 
 
+# | Reference, also return type
 @plugin
 def at(objects: "list", index: "int") -> "any":
     """
@@ -566,11 +617,13 @@ def at(objects: "list", index: "int") -> "any":
     return objects[int(index)]
 
 
+# | Reference on return type
 @plugin
 def attr(obj: "any", attr: "string") -> "any":
     return getattr(obj, attr)
 
 
+# | Reference
 @plugin
 def isset(value: "any") -> "bool":
     """
@@ -579,6 +632,7 @@ def isset(value: "any") -> "bool":
     return value is not None
 
 
+# | Reference
 @plugin
 def objid(value: "any") -> "string":
     return str(
@@ -590,6 +644,7 @@ def objid(value: "any") -> "string":
     )
 
 
+# | Reference
 @plugin
 def count(item_list: "list") -> "int":
     """
@@ -601,6 +656,7 @@ def count(item_list: "list") -> "int":
     return len(item_list)
 
 
+# | Reference
 @plugin("len")
 def list_len(item_list: "list") -> "int":
     """
@@ -627,6 +683,7 @@ def unique(item_list: "list") -> "bool":
     return True
 
 
+# | Reference
 @plugin
 def flatten(item_list: "list") -> "list":
     """
@@ -1037,6 +1094,7 @@ def contains(dct: "dict", key: "string") -> "bool":
     return key in dct
 
 
+# | Reference?
 @plugin("getattr", allow_unknown=True)
 def getattribute(
     entity: "std::Entity",
@@ -1077,6 +1135,7 @@ def list_files(ctx: Context, path: "string") -> "list":
     return [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
 
 
+# TODO: | Reference?
 @plugin(allow_unknown=True)
 def is_unknown(value: "any") -> "bool":
     return isinstance(value, Unknown)

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -140,7 +140,7 @@ class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
             return cls.wrap(super().return_value(value))
 
         # context was introduced after references
-        assert Reference is not MockReference
+        assert Reference is not MockReference  # type: ignore
         # core's DynamicProxy takes care of references on-proxy. But we have to guard top-level references here because
         # they are never rejected at runtime on the plugin boundary (core's normal operating mode).
         if isinstance(value, Reference):
@@ -218,14 +218,14 @@ class JinjaIteratorProxy(JinjaDynamicProxy[proxy.IteratorProxy]):
         return self.wrap(next(self._get_delegate()))
 
 
-class JinjaGetItemProxy[P: proxy.SequenceProxy | proxy.DictProxy](
+class JinjaGetItemProxy[K: int | str, P: proxy.SequenceProxy | proxy.DictProxy](
     JinjaDynamicProxy[P]
 ):
     """
     Jinja-compatible proxy for __getitem__ (ABC).
     """
 
-    def __getitem__(self, key: object) -> object:
+    def __getitem__(self, key: K) -> object:
         return self.wrap(self._get_delegate()[key])
 
     def __iter__(self) -> object:
@@ -235,13 +235,13 @@ class JinjaGetItemProxy[P: proxy.SequenceProxy | proxy.DictProxy](
         return len(self._get_delegate())
 
 
-class JinjaSequenceProxy(JinjaGetItemProxy[proxy.SequenceProxy]):
+class JinjaSequenceProxy(JinjaGetItemProxy[int, proxy.SequenceProxy]):
     """
     Jinja-compatible sequence proxy.
     """
 
 
-class JinjaDictProxy(JinjaGetItemProxy[proxy.DictProxy]):
+class JinjaDictProxy(JinjaGetItemProxy[str, proxy.DictProxy]):
     """
     Jinja-compatible dict proxy.
     """

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -17,14 +17,14 @@ Contact: code@inmanta.com
 """
 
 import contextlib
-import pytest
 import re
 from collections.abc import Iterator
-from pytest_inmanta.plugin import Project
 from typing import Optional
 
-from inmanta import const
-from inmanta import ast
+import pytest
+from pytest_inmanta.plugin import Project
+
+from inmanta import ast, const
 
 try:
     from inmanta.references import Reference, reference  # noqa: F401
@@ -36,7 +36,9 @@ except ImportError:
 
 # modified from inmanta-core/tests/test_references.py
 @contextlib.contextmanager
-def raises_wrapped(exc_tp: type[ast.RuntimeException], *, match: Optional[str] = None) -> Iterator[None]:
+def raises_wrapped(
+    exc_tp: type[ast.RuntimeException], *, match: Optional[str] = None
+) -> Iterator[None]:
     """
     Context manager wrapper around pytest.raises. Expects a WrappingRuntimeException to be raised, and asserts that it wraps
     the provided exception type and that its message matches the provided pattern.
@@ -186,7 +188,10 @@ def test_references_in_jinja(project: Project) -> None:
         "Hello {{ world }}",
     )
 
-    with pytest.raises(ast.ExplicitPluginException, match="Encountered reference in Jinja template for variable world"):
+    with pytest.raises(
+        ast.ExplicitPluginException,
+        match="Encountered reference in Jinja template for variable world",
+    ):
         project.compile(
             """\
             import unittest
@@ -202,7 +207,10 @@ def test_references_in_jinja(project: Project) -> None:
         "testtemplate.j2",
         "Hello {{ world.name }}",
     )
-    with raises_wrapped(ast.UnexpectedReference, match="Encountered unexpected reference .* Encountered at world.name"):
+    with raises_wrapped(
+        ast.UnexpectedReference,
+        match="Encountered unexpected reference .* Encountered at world.name",
+    ):
         project.compile(
             """\
             import unittest
@@ -223,7 +231,10 @@ def test_references_in_jinja(project: Project) -> None:
         "testtemplate.j2",
         "Hello {{ world[0].name }}",
     )
-    with raises_wrapped(ast.UnexpectedReference, match=r"Encountered unexpected reference .* Encountered at world\[0\].name"):
+    with raises_wrapped(
+        ast.UnexpectedReference,
+        match=r"Encountered unexpected reference .* Encountered at world\[0\].name",
+    ):
         project.compile(
             """\
             import unittest

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -16,10 +16,15 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import contextlib
 import pytest
+import re
+from collections.abc import Iterator
 from pytest_inmanta.plugin import Project
+from typing import Optional
 
 from inmanta import const
+from inmanta import ast
 
 try:
     from inmanta.references import Reference, reference  # noqa: F401
@@ -27,6 +32,21 @@ except ImportError:
     pytestmark = pytest.skip(
         "Reference are not yet supported by this core version", allow_module_level=True
     )
+
+
+# modified from inmanta-core/tests/test_references.py
+@contextlib.contextmanager
+def raises_wrapped(exc_tp: type[ast.RuntimeException], *, match: Optional[str] = None) -> Iterator[None]:
+    """
+    Context manager wrapper around pytest.raises. Expects a WrappingRuntimeException to be raised, and asserts that it wraps
+    the provided exception type and that its message matches the provided pattern.
+    """
+    with pytest.raises(ast.WrappingRuntimeException) as exc_info:
+        yield
+    assert isinstance(exc_info.value.__cause__, exc_tp)
+    if match is not None:
+        msg: str = exc_info.value.__cause__.format()
+        assert re.search(match, msg) is not None, msg
 
 
 def test_references_resource(project: Project, monkeypatch) -> None:
@@ -127,3 +147,94 @@ def test_fact_references(project: Project) -> None:
         expected_status=const.ResourceState.deployed,
     )
     assert result.assert_has_logline("Observed value: my_value")
+
+
+def test_references_in_plugins(project: Project) -> None:
+    """
+    Verify that plugins that allow references work as expected. Does not verify results since those should be tested by
+    specific implementation tests. Only verifies that no validation errors are raised.
+    """
+    project.compile(
+        """\
+        ref = std::create_environment_reference("HELLO")
+
+        entity A:
+            string s
+        end
+        implement A using std::none
+
+
+        std::print(ref)
+        std::at([ref], 0)
+        std::attr(A(s=ref), "s")
+        std::count([ref])
+        std::len([ref])
+        std::getattr(A(s=ref), "s")
+        std::getattr(A(s="Hello World!"), "doesnotexist", default_value=ref)
+        std::is_unknown(ref)
+        """
+    )
+
+
+def test_references_in_jinja(project: Project) -> None:
+    """
+    Verify behavior of Jinja template when it encounters reference values.
+    """
+    project.add_mock_file(
+        "templates",
+        "testtemplate.j2",
+        "Hello {{ world }}",
+    )
+
+    with pytest.raises(ast.ExplicitPluginException, match="Encountered reference in Jinja template for variable world"):
+        project.compile(
+            """\
+            import unittest
+
+            world = std::create_environment_reference("WORLD")
+
+            std::template("unittest/testtemplate.j2")
+            """
+        )
+
+    project.add_mock_file(
+        "templates",
+        "testtemplate.j2",
+        "Hello {{ world.name }}",
+    )
+    with raises_wrapped(ast.UnexpectedReference, match="Encountered unexpected reference .* Encountered at world.name"):
+        project.compile(
+            """\
+            import unittest
+
+            entity World:
+                string name
+            end
+            implement World using std::none
+
+            world = World(name=std::create_environment_reference("WORLD"))
+
+            std::template("unittest/testtemplate.j2")
+            """
+        )
+
+    project.add_mock_file(
+        "templates",
+        "testtemplate.j2",
+        "Hello {{ world[0].name }}",
+    )
+    with raises_wrapped(ast.UnexpectedReference, match=r"Encountered unexpected reference .* Encountered at world\[0\].name"):
+        project.compile(
+            """\
+            import unittest
+
+            entity World:
+                string name
+            end
+            implement World using std::none
+
+            world = [World(name=std::create_environment_reference("WORLD"))]
+
+            std::template("unittest/testtemplate.j2")
+            """
+        )


### PR DESCRIPTION
# Description

- Reject reference values during Jinja template evaluation
- Allow reference values for some basic plugins

Both require the latest changes on inmanta-core to be effective, including inmanta/inmanta-core#9277 (draft). For older versions of inmanta-core, the old behavior is kept.

Implementation is more verbose than I'd like, but considering that we have to remain backwards compatible, I don't think anything can really be done about that.

part of inmanta/inmanta-core#9262


note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. Wait for tests to pass
3. Add the tag and push it back


```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
4. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

