### PR TITLE
updated constraints in requirements.txt to version pins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-# explicitly use >=,< rather than ~= to force dependabot to widen constraints even though this is conventionally a lock file
-Jinja2>=3.1.6,<4
-email_validator>=2.3.0,<3
-pydantic>=2.13.3,<3
-inmanta-core>=18.0.1
+Jinja2==3.1.6
+email_validator==2.3.0
+pydantic==2.13.3


### PR DESCRIPTION
# Description

The `requirements.txt` had wide constraints for module v1 compatibility. We no longer need that compatibility so we can start using it as an actual lock file.
Apart from the above (which is sufficient motivation already), dependabot started bumping these, which caused an incompatibility on the inmanta-core requirement. At the very least inmanta-core had to be dropped from the file.

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. Wait for tests to pass
3. Add the tag and push it back


```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
4. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

