### PR TITLE
Collect all unset values in std::template in a single render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v8.7.5 - ?
 
+- Improved the performance of `std::template` for templates that read many values which are not set yet. Such a template used
+  to be re-rendered once per unset value, because the render aborted at the first one it encountered. It is now rendered once
+  in a discovery pass which collects every unset value it reads, so the compiler can wait for all of them at once and a single
+  extra render suffices. Requires inmanta-core 15.1 or later; on older versions the previous behaviour is kept.
 - Removed the `std::AgentConfig` handler and stopped exporting `std::AgentConfig` resources. The orchestrator dropped the
   autostarted_agent_map setting in inmanta-core 15 (ISO8), so the handler already made no changes and only logged that fact
   on every deploy. This also removes std's only import of `inmanta.data`, which pulled the whole database layer, including

--- a/inmanta_plugins/std/__init__.py
+++ b/inmanta_plugins/std/__init__.py
@@ -18,6 +18,7 @@ Contact: code@inmanta.com
 
 import base64
 import builtins
+import contextvars
 import hashlib
 import importlib
 import ipaddress
@@ -44,7 +45,12 @@ from jinja2.runtime import Undefined, missing
 import inmanta.resources
 from inmanta import util
 from inmanta.agent.handler import LoggerABC
-from inmanta.ast import NotFoundException, OptionalValueException, RuntimeException
+from inmanta.ast import (
+    NotFoundException,
+    OptionalValueException,
+    RuntimeException,
+    UnsetException,
+)
 from inmanta.config import Config
 from inmanta.execute import proxy
 from inmanta.execute.util import NoneValue, Unknown
@@ -68,6 +74,25 @@ except ImportError:
 
     def allow_reference_values[T](instance: T) -> T:
         return instance
+
+
+supports_batched_unset: bool
+try:
+    from inmanta.ast import MultiUnsetException
+
+    supports_batched_unset = True
+except ImportError:
+    # older inmanta-core versions (<15.1) can not be told to wait for multiple
+    # values at once => keep rescheduling on the first unset value we encounter
+    supports_batched_unset = False
+
+# Exceptions that signal the compiler that a value is not available yet, and that
+# it should reschedule us once it is.
+unset_exceptions: tuple[builtins.type[Exception], ...] = (
+    (UnsetException, MultiUnsetException)
+    if supports_batched_unset
+    else (UnsetException,)
+)
 
 
 class MockReference:
@@ -106,6 +131,53 @@ def inmanta_reset_state() -> None:
     tcache = {}
     engine_cache = None
     fact_cache = {}
+
+
+# --- One-pass dependency discovery -------------------------------------------
+#
+# Rendering a template reads many model values.  When the first one that is not
+# frozen yet raises UnsetException, the whole render aborts and the compiler
+# reschedules and fully re-runs the template.  A template that reads K still
+# unset values is therefore rendered up to K+1 times.
+#
+# Instead we render once in "discovery" mode: every unset value encountered is
+# collected and replaced by a chaining-undefined, so that the render keeps going
+# and reaches the other (independent) unset values.  If anything was collected,
+# the render output is discarded and a single MultiUnsetException is raised for
+# the whole batch, so the compiler waits for all of them at once and re-invokes
+# us.  Only a pass that observes zero misses used real values throughout, so
+# only its output is ever returned, which keeps the result identical to
+# rescheduling on every single miss.
+unset_collector: contextvars.ContextVar[Optional[set[object]]] = contextvars.ContextVar(
+    "std_template_unset_collector", default=None
+)
+
+
+def collect_or_raise(exc: UnsetException) -> object:
+    """
+    During a discovery render, record the unset value and return a
+    chaining-undefined so that rendering can continue.  Outside of a discovery
+    render (no active collector) propagate the exception, preserving the original
+    per-miss rescheduling behaviour.
+    """
+    collector = unset_collector.get()
+    variable = exc.get_result_variable()
+    if collector is None or variable is None:
+        raise exc
+
+    collector.add(variable)
+    return jinja2.ChainableUndefined(hint=exc.msg)
+
+
+def batched_unset(template_path: str, collector: set[object]) -> "MultiUnsetException":
+    """
+    Build the exception that makes the compiler wait for all the values collected
+    during a discovery render at once.
+    """
+    return MultiUnsetException(
+        f"Template {template_path} accessed values that were not set yet",
+        list(collector),
+    )
 
 
 class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
@@ -213,6 +285,8 @@ class JinjaDynamicProxy[P: proxy.DynamicProxy](proxy.DynamicProxy):
                     instance,
                     name,
                 )
+            except UnsetException as e:
+                return collect_or_raise(e)
             return self.wrap(attr)
         else:
             # A native python object. Not supported by core's DynamicProxy
@@ -288,6 +362,8 @@ class ResolverContext(jinja2.runtime.Context):
             )
         except OptionalValueException:
             return missing
+        except UnsetException as e:
+            return collect_or_raise(e)
 
 
 class EmptyResolver:
@@ -395,10 +471,35 @@ def template(ctx: Context, path: "string", **kwargs: "any") -> "string":
         variables = dict(kwargs)
         variables["{{resolver"] = EmptyResolver()
 
+    # Render once in discovery mode: collect every unset model value instead of
+    # aborting at the first one (see collect_or_raise).  If any were missing, wait
+    # for the whole batch at once rather than rescheduling per miss.
+    collector: set[object] = set()
+    token = unset_collector.set(collector) if supports_batched_unset else None
     try:
-        return template.render(variables)
-    except UndefinedError as e:
-        raise NotFoundException(ctx.owner, None, e.message)
+        rendered = template.render(variables)
+    except unset_exceptions:
+        # Raised by a nested template or plugin: propagate unchanged.
+        raise
+    except Exception as e:
+        # A collected unset value can cascade into a downstream error during the
+        # discovery render (e.g. a chaining-undefined reaching a plugin filter).
+        # If we collected any misses, that error is presumed to be a consequence
+        # of them: wait for the batch and retry.  A genuine error surfaces
+        # unchanged on the final pass, where nothing is collected.
+        if collector:
+            raise batched_unset(template_path, collector) from None
+        if isinstance(e, UndefinedError):
+            raise NotFoundException(ctx.owner, None, e.message)
+        raise
+    finally:
+        if token is not None:
+            unset_collector.reset(token)
+
+    if collector:
+        raise batched_unset(template_path, collector)
+
+    return rendered
 
 
 @dependency_manager

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -20,9 +20,11 @@ import os
 import shutil
 from typing import Dict
 
+import jinja2
 import pytest
 import pytest_inmanta.plugin
 
+import inmanta_plugins.std
 from inmanta import ast
 
 
@@ -331,6 +333,113 @@ def test_if_defined_with_plugin_call(project):
     std::print(std::template("unittest/test.j2"))
             """)
     assert "myvar is not defined" in project.get_stdout()
+
+
+def test_one_pass_unset_discovery(project, monkeypatch):
+    """
+    A template that reads several model values which are not frozen yet is
+    rendered once in "discovery" mode: all the unset values are collected in a
+    single pass and waited for at once, instead of rescheduling the whole render
+    once per miss.
+    """
+    project.add_mock_file(
+        "templates",
+        "multi.j2",
+        "{% for item in config.a %}{{ item.name }}{% endfor %}-"
+        "{% for item in config.b %}{{ item.name }}{% endfor %}-"
+        "{% for item in config.c %}{{ item.name }}{% endfor %}",
+    )
+
+    # Count the renders of our template, and record how many misses the collector
+    # held at each collection during a discovery pass.
+    render_count = 0
+    original_render = jinja2.Template.render
+
+    def counting_render(self, *args, **kwargs):
+        nonlocal render_count
+        if self.name == "multi.j2":
+            render_count += 1
+        return original_render(self, *args, **kwargs)
+
+    pass_sizes: list[int] = []
+    original_collect = inmanta_plugins.std.collect_or_raise
+
+    def spy_collect(exc):
+        result = original_collect(exc)
+        collector = inmanta_plugins.std.unset_collector.get()
+        if collector is not None:
+            pass_sizes.append(len(collector))
+        return result
+
+    monkeypatch.setattr(jinja2.Template, "render", counting_render)
+    monkeypatch.setattr(inmanta_plugins.std, "collect_or_raise", spy_collect)
+
+    # The three relations are only populated further down the model, so they are
+    # all unfrozen when the template plugin is first evaluated.
+    project.compile("""
+import std
+import unittest
+
+entity Config:
+end
+
+entity Item:
+    string name
+end
+
+Config.a [0:] -- Item.config_a [0:1]
+Config.b [0:] -- Item.config_b [0:1]
+Config.c [0:] -- Item.config_c [0:1]
+
+implement Config using std::none
+implement Item using std::none
+
+config = Config()
+std::print(std::template("unittest/multi.j2"))
+
+Item(name="A", config_a=config)
+Item(name="B", config_b=config)
+Item(name="C", config_c=config)
+    """)
+
+    # The template was rendered correctly, with all the deferred values.
+    assert project.get_stdout().strip() == "A-B-C"
+
+    # A single discovery pass collected all three misses at once: the per-miss
+    # behaviour could never hold more than one miss in a single render.
+    assert max(pass_sizes) == 3
+    # One discovery render that collected the batch, then one clean render.
+    assert render_count == 2
+
+
+def test_unset_value_reaching_plugin_filter(project):
+    """
+    An unset value collected during a discovery render is replaced by an
+    undefined, which cascades into an error when it reaches a plugin filter.  That
+    error must not surface: the batch of collected values is waited for instead,
+    and the next render sees the real value.
+    """
+    project.add_mock_file("templates", "filter.j2", "{{ config.value | std.upper }}")
+
+    project.compile("""
+import std
+import unittest
+
+entity Config:
+    string value
+end
+
+implementation compute for Config:
+    self.value = "hello"
+end
+
+implement Config using compute
+
+config = Config()
+std::print(std::template("unittest/filter.j2"))
+    """)
+
+    assert project.get_stdout().strip() == "HELLO"
 
 
 def test_plugin_in_template_without_args(project):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -335,6 +335,10 @@ def test_if_defined_with_plugin_call(project):
     assert "myvar is not defined" in project.get_stdout()
 
 
+@pytest.mark.skipif(
+    not inmanta_plugins.std.supports_batched_unset,
+    reason="inmanta-core<15.1 can not be told to wait for multiple values at once",
+)
 def test_one_pass_unset_discovery(project, monkeypatch):
     """
     A template that reads several model values which are not frozen yet is


### PR DESCRIPTION
# Description

Ports the one-pass unset-value discovery from `future::std::jinja` to `std::template`.

Rendering a template reads many model values. When the first one that is not frozen yet raised `UnsetException`, the whole render aborted and the compiler rescheduled and fully re-ran the template — a template reading K still-unset values was rendered up to K+1 times.

`std::template` now renders once in *discovery* mode: every unset value it encounters is collected and replaced by a `jinja2.ChainableUndefined`, so the render keeps going and reaches the other, independent, unset values. If anything was collected the output is discarded and a single `MultiUnsetException` is raised for the whole batch, so the compiler waits for all of them at once. Only a pass that observed zero misses used real values throughout, so only its output is ever returned — the rendered result is unchanged.

Two places surface an `UnsetException` mid-render, both hooked:

* `JinjaDynamicProxy.__getattr__` — attribute and relation access (`{{ config.a }}`)
* `ResolverContext.resolve_or_missing` — top-level model variables

std owns `JinjaDynamicProxy`, so unlike `future::std` no monkeypatching of core is needed.

A collected undefined can cascade into a downstream error during the discovery render, e.g. when it reaches a plugin filter. When anything was collected, such an error is treated as a consequence of the misses and the batch is waited for instead; a genuine error surfaces unchanged on the final pass, where nothing is collected. `test_unset_value_reaching_plugin_filter` covers this.

### Backwards compatibility

`MultiUnsetException` was introduced in inmanta-core 15.1 ([`0545a9570`](https://github.com/inmanta/inmanta-core/commit/0545a9570b3dff631b5b473383e1729c130596e4)) while std declares `inmanta-core>=15.0`, so the collector is only installed when core supports it. On 15.0.x the per-miss behaviour is kept. Happy to drop the guard and raise the floor to 15.1 instead if that is preferred.

### Measured effect

`test_one_pass_unset_discovery` renders a template reading three independently-frozen `[0:]` relations. With the collector disabled the template is rendered **4** times; with it, **2** — one discovery pass that collects all three misses at once, then one clean pass.

closes [#678](https://github.com/inmanta/std/issues/678)

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)

1. merge using the merge button
2. Wait for tests to pass
3. Add the tag and push it back

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
4. Remove the branch

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- ~~End user documentation is included or an issue is created for end-user documentation~~